### PR TITLE
Add widow mines to trigger cloak detection

### DIFF
--- a/sharpy/managers/enemy_units_manager.py
+++ b/sharpy/managers/enemy_units_manager.py
@@ -121,6 +121,9 @@ class EnemyUnitsManager(ManagerBase):
         if self.unit_count(UnitTypeId.BANSHEE) > 0:
             self._enemy_cloak_trigger = True
 
+        if self.unit_count(UnitTypeId.WIDOWMINE) > 0:
+            self._enemy_cloak_trigger = True
+
         if self.unit_count(UnitTypeId.LURKER) > 0 or \
                 self.knowledge.known_enemy_structures.of_type(
                     [UnitTypeId.LURKERDENMP, UnitTypeId.LURKERDEN]).exists:


### PR DESCRIPTION
I had this untested change laying around. It should be a good idea to trigger cloak detection if enemy has Widow Mines, right?