### PR TITLE
ActTech no longer requires building type

### DIFF
--- a/dummies/protoss/adept_allin.py
+++ b/dummies/protoss/adept_allin.py
@@ -53,7 +53,7 @@ class AdeptRush(KnowledgeBot):
                         [
                             Step(None, GridBuilding(UnitTypeId.CYBERNETICSCORE, 1), skip_until=RequiredUnitReady(UnitTypeId.GATEWAY, 1)),
                             Step(RequiredUnitReady(UnitTypeId.CYBERNETICSCORE, 1), GateUnit(UnitTypeId.ADEPT, 2, only_once=True)),
-                            ActTech(UpgradeId.WARPGATERESEARCH, UnitTypeId.CYBERNETICSCORE),
+                            ActTech(UpgradeId.WARPGATERESEARCH),
                             GateUnit(UnitTypeId.ADEPT, 100)
                         ]),
                         Step(RequiredUnitExists(UnitTypeId.CYBERNETICSCORE, 1), GridBuilding(UnitTypeId.GATEWAY, 4),

--- a/dummies/protoss/cannon_rush.py
+++ b/dummies/protoss/cannon_rush.py
@@ -226,9 +226,9 @@ class CannonRush(KnowledgeBot):
                         AutoPylon(),
                         ProtossUnit(UnitTypeId.STALKER, 4, priority=True),
                         StepBuildGas(3, skip=RequiredGas(300)),
-                        ActTech(UpgradeId.WARPGATERESEARCH, UnitTypeId.CYBERNETICSCORE),
+                        ActTech(UpgradeId.WARPGATERESEARCH),
                         BuildOrder([]).forge_upgrades_all,
-                        Step(RequiredUnitReady(UnitTypeId.TWILIGHTCOUNCIL, 1), ActTech(UpgradeId.BLINKTECH, UnitTypeId.TWILIGHTCOUNCIL)),
+                        Step(RequiredUnitReady(UnitTypeId.TWILIGHTCOUNCIL, 1), ActTech(UpgradeId.BLINKTECH)),
                         [
                             ProtossUnit(UnitTypeId.PROBE, 22),
                             Step(RequiredUnitExists(UnitTypeId.NEXUS, 2),

--- a/dummies/protoss/dark_templar_rush.py
+++ b/dummies/protoss/dark_templar_rush.py
@@ -52,8 +52,8 @@ class DarkTemplarRush(KnowledgeBot):
             Step(RequiredUnitReady(UnitTypeId.GATEWAY, 1), GridBuilding(UnitTypeId.CYBERNETICSCORE, 1)),
             Step(RequiredUnitReady(UnitTypeId.CYBERNETICSCORE, 1), GridBuilding(UnitTypeId.TWILIGHTCOUNCIL, 1)),
             Step(RequiredUnitReady(UnitTypeId.TWILIGHTCOUNCIL, 1), GridBuilding(UnitTypeId.DARKSHRINE, 1)),
-            ActTech(UpgradeId.BLINKTECH, UnitTypeId.TWILIGHTCOUNCIL),
-            ActTech(UpgradeId.CHARGE, UnitTypeId.TWILIGHTCOUNCIL)
+            ActTech(UpgradeId.BLINKTECH),
+            ActTech(UpgradeId.CHARGE)
         ]
 
         build_steps_workers = [
@@ -78,7 +78,7 @@ class DarkTemplarRush(KnowledgeBot):
             StepBuildGas(2),
             Step(RequiredSupply(21), GridBuilding(UnitTypeId.PYLON, 2), RequiredUnitExists(UnitTypeId.PYLON, 2)),
             GridBuilding(UnitTypeId.GATEWAY, 2),
-            Step(RequiredUnitReady(UnitTypeId.CYBERNETICSCORE, 1), ActTech(UpgradeId.WARPGATERESEARCH, UnitTypeId.CYBERNETICSCORE)),
+            Step(RequiredUnitReady(UnitTypeId.CYBERNETICSCORE, 1), ActTech(UpgradeId.WARPGATERESEARCH)),
 
             GridBuilding(UnitTypeId.GATEWAY, 3),
             AutoPylon()

--- a/dummies/protoss/gate4.py
+++ b/dummies/protoss/gate4.py
@@ -35,13 +35,13 @@ class Stalkers4Gate(KnowledgeBot):
                         SequentialList(
                         [
                             Step(RequiredUnitReady(UnitTypeId.CYBERNETICSCORE, 1), GridBuilding(UnitTypeId.TWILIGHTCOUNCIL, 1)),
-                            Step(RequiredUnitReady(UnitTypeId.TWILIGHTCOUNCIL, 1), ActTech(UpgradeId.BLINKTECH, UnitTypeId.TWILIGHTCOUNCIL)),
+                            Step(RequiredUnitReady(UnitTypeId.TWILIGHTCOUNCIL, 1), ActTech(UpgradeId.BLINKTECH)),
                         ]),
                         SequentialList(
                         [
                             Step(None, GridBuilding(UnitTypeId.CYBERNETICSCORE, 1), skip_until=RequiredUnitReady(UnitTypeId.GATEWAY, 1)),
                             Step(RequiredUnitReady(UnitTypeId.CYBERNETICSCORE, 1), GateUnit(UnitTypeId.ADEPT, 2, only_once=True)),
-                            ActTech(UpgradeId.WARPGATERESEARCH, UnitTypeId.CYBERNETICSCORE),
+                            ActTech(UpgradeId.WARPGATERESEARCH),
                             GateUnit(UnitTypeId.STALKER, 100)
                         ]),
                         Step(RequiredUnitExists(UnitTypeId.CYBERNETICSCORE, 1), GridBuilding(UnitTypeId.GATEWAY, 4))

--- a/dummies/protoss/macro_stalkers.py
+++ b/dummies/protoss/macro_stalkers.py
@@ -34,7 +34,7 @@ class MacroStalkers(KnowledgeBot):
                 BuildOrder(
                     [
                         AutoPylon(),
-                        ActTech(UpgradeId.WARPGATERESEARCH, UnitTypeId.CYBERNETICSCORE),
+                        ActTech(UpgradeId.WARPGATERESEARCH),
                         [
                             ActUnit(UnitTypeId.PROBE, UnitTypeId.NEXUS, 22),
                             Step(RequiredUnitExists(UnitTypeId.NEXUS, 2), ActUnit(UnitTypeId.PROBE, UnitTypeId.NEXUS, 44)),

--- a/dummies/protoss/proxy_zealot_rush.py
+++ b/dummies/protoss/proxy_zealot_rush.py
@@ -140,7 +140,7 @@ class ProxyZealotRushBot(KnowledgeBot):
                     [
                         AutoPylon(),
                         GateUnit(UnitTypeId.STALKER, 2, priority=True),
-                        ActTech(UpgradeId.WARPGATERESEARCH, UnitTypeId.CYBERNETICSCORE),
+                        ActTech(UpgradeId.WARPGATERESEARCH),
                         [
                             ActUnit(UnitTypeId.PROBE, UnitTypeId.NEXUS, 22),
                             Step(RequiredUnitExists(UnitTypeId.NEXUS, 2),
@@ -156,9 +156,9 @@ class ProxyZealotRushBot(KnowledgeBot):
                                      GridBuilding(UnitTypeId.TWILIGHTCOUNCIL, 1)),
                                 GridBuilding(UnitTypeId.STARGATE, 1),
                                 Step(RequiredUnitReady(UnitTypeId.TWILIGHTCOUNCIL, 1),
-                                     ActTech(UpgradeId.CHARGE, UnitTypeId.TWILIGHTCOUNCIL)),
+                                     ActTech(UpgradeId.CHARGE)),
                                 Step(RequiredUnitReady(UnitTypeId.TWILIGHTCOUNCIL, 1),
-                                     ActTech(UpgradeId.ADEPTPIERCINGATTACK, UnitTypeId.TWILIGHTCOUNCIL)),
+                                     ActTech(UpgradeId.ADEPTPIERCINGATTACK)),
                             ]),
                         [
                             ActUnit(UnitTypeId.VOIDRAY, UnitTypeId.STARGATE, 20, priority=True)

--- a/dummies/protoss/robo.py
+++ b/dummies/protoss/robo.py
@@ -46,7 +46,7 @@ class MacroRobo(KnowledgeBot):
                 [
                     AutoPylon(),
                     GateUnit(UnitTypeId.STALKER, 2, priority=True),
-                    ActTech(UpgradeId.WARPGATERESEARCH, UnitTypeId.CYBERNETICSCORE),
+                    ActTech(UpgradeId.WARPGATERESEARCH),
                     [
                         ActUnit(UnitTypeId.PROBE, UnitTypeId.NEXUS, 22),
                         Step(RequiredUnitExists(UnitTypeId.NEXUS, 2), ActUnit(UnitTypeId.PROBE, UnitTypeId.NEXUS, 44)),
@@ -60,7 +60,7 @@ class MacroRobo(KnowledgeBot):
                              GridBuilding(UnitTypeId.TWILIGHTCOUNCIL, 1)),
                         GridBuilding(UnitTypeId.ROBOTICSFACILITY, 1),
                         Step(RequiredUnitReady(UnitTypeId.TWILIGHTCOUNCIL, 1),
-                             ActTech(UpgradeId.CHARGE, UnitTypeId.TWILIGHTCOUNCIL)),
+                             ActTech(UpgradeId.CHARGE)),
                     ]),
                     [
                         ActUnit(UnitTypeId.IMMORTAL, UnitTypeId.ROBOTICSFACILITY, 1, priority=True),

--- a/dummies/protoss/voidray.py
+++ b/dummies/protoss/voidray.py
@@ -45,7 +45,7 @@ class MacroVoidray(KnowledgeBot):
                 [
                     AutoPylon(),
                     GateUnit(UnitTypeId.STALKER, 2, priority=True),
-                    ActTech(UpgradeId.WARPGATERESEARCH, UnitTypeId.CYBERNETICSCORE),
+                    ActTech(UpgradeId.WARPGATERESEARCH),
                     [
                         ProtossUnit(UnitTypeId.PROBE, 22),
                         Step(RequiredUnitExists(UnitTypeId.NEXUS, 2), ProtossUnit(UnitTypeId.PROBE, 44)),
@@ -59,9 +59,9 @@ class MacroVoidray(KnowledgeBot):
                              GridBuilding(UnitTypeId.TWILIGHTCOUNCIL, 1)),
                         GridBuilding(UnitTypeId.STARGATE, 1),
                         Step(RequiredUnitReady(UnitTypeId.TWILIGHTCOUNCIL, 1),
-                             ActTech(UpgradeId.CHARGE, UnitTypeId.TWILIGHTCOUNCIL)),
+                             ActTech(UpgradeId.CHARGE)),
                         Step(RequiredUnitReady(UnitTypeId.TWILIGHTCOUNCIL, 1),
-                             ActTech(UpgradeId.ADEPTPIERCINGATTACK, UnitTypeId.TWILIGHTCOUNCIL)),
+                             ActTech(UpgradeId.ADEPTPIERCINGATTACK)),
                     ]),
                     [
                         ProtossUnit(UnitTypeId.VOIDRAY, 20, priority=True)

--- a/dummies/terran/banshees.py
+++ b/dummies/terran/banshees.py
@@ -78,7 +78,7 @@ class Banshees(KnowledgeBot):
                 Step(None, GridBuilding(UnitTypeId.STARPORT, 2)),
 
                 Step(RequiredUnitReady(UnitTypeId.STARPORT, 2), ActBuildAddon(UnitTypeId.STARPORTTECHLAB, UnitTypeId.STARPORT, 2)),
-                Step(None, ActTech(UpgradeId.SHIELDWALL, UnitTypeId.BARRACKSTECHLAB)),
+                Step(None, ActTech(UpgradeId.SHIELDWALL)),
 
                 Step(RequiredMinerals(600), GridBuilding(UnitTypeId.BARRACKS, 5)),
                 ActExpand(3),

--- a/dummies/terran/battle_cruisers.py
+++ b/dummies/terran/battle_cruisers.py
@@ -98,7 +98,7 @@ class BattleCruisers(KnowledgeBot):
                 Step(None, GridBuilding(UnitTypeId.STARPORT, 2)),
 
                 Step(RequiredUnitReady(UnitTypeId.STARPORT, 2), ActBuildAddon(UnitTypeId.STARPORTTECHLAB, UnitTypeId.STARPORT, 2)),
-                Step(None, ActTech(UpgradeId.SHIELDWALL, UnitTypeId.BARRACKSTECHLAB)),
+                Step(None, ActTech(UpgradeId.SHIELDWALL)),
 
                 Step(RequiredMinerals(600), GridBuilding(UnitTypeId.BARRACKS, 5)),
                 ActExpand(3),

--- a/dummies/terran/bio.py
+++ b/dummies/terran/bio.py
@@ -99,9 +99,9 @@ class BuildBio(BuildOrder):
         ]
 
         tech = [
-            Step(None, ActTech(UpgradeId.PUNISHERGRENADES, UnitTypeId.BARRACKSTECHLAB)),
-            Step(None, ActTech(UpgradeId.STIMPACK, UnitTypeId.BARRACKSTECHLAB)),
-            Step(None, ActTech(UpgradeId.SHIELDWALL, UnitTypeId.BARRACKSTECHLAB)),
+            Step(None, ActTech(UpgradeId.PUNISHERGRENADES)),
+            Step(None, ActTech(UpgradeId.STIMPACK)),
+            Step(None, ActTech(UpgradeId.SHIELDWALL)),
         ]
 
         mech = [

--- a/dummies/terran/cyclones.py
+++ b/dummies/terran/cyclones.py
@@ -33,10 +33,10 @@ class CycloneBot(KnowledgeBot):
             Step(None, ActExpand(3)),
             GridBuilding(UnitTypeId.FACTORY, 2),
             ActBuildAddon(UnitTypeId.FACTORYTECHLAB, UnitTypeId.FACTORY, 2),
-            Step(None, ActTech(UpgradeId.CYCLONELOCKONDAMAGEUPGRADE, UnitTypeId.FACTORYTECHLAB),
+            Step(None, ActTech(UpgradeId.CYCLONELOCKONDAMAGEUPGRADE),
                  skip_until=RequiredUnitReady(UnitTypeId.FACTORYTECHLAB, 1)),
             StepBuildGas(5),
-            Step(None, ActTech(UpgradeId.HIGHCAPACITYBARRELS, UnitTypeId.FACTORYTECHLAB),
+            Step(None, ActTech(UpgradeId.HIGHCAPACITYBARRELS),
                  skip_until=RequiredUnitReady(UnitTypeId.FACTORYTECHLAB, 2)),
             StepBuildGas(6, None, RequiredGas(100)),
             Step(RequiredMinerals(400), GridBuilding(UnitTypeId.FACTORY, 4)),
@@ -53,12 +53,12 @@ class CycloneBot(KnowledgeBot):
         ]
 
         upgrades = [
-            Step(RequiredUnitReady(UnitTypeId.ARMORY, 1), ActTech(UpgradeId.TERRANVEHICLEWEAPONSLEVEL1, UnitTypeId.ARMORY)),
-            ActTech(UpgradeId.TERRANVEHICLEANDSHIPARMORSLEVEL1, UnitTypeId.ARMORY),
-            ActTech(UpgradeId.TERRANVEHICLEWEAPONSLEVEL2, UnitTypeId.ARMORY),
-            ActTech(UpgradeId.TERRANVEHICLEANDSHIPARMORSLEVEL2, UnitTypeId.ARMORY),
-            ActTech(UpgradeId.TERRANVEHICLEWEAPONSLEVEL3, UnitTypeId.ARMORY),
-            ActTech(UpgradeId.TERRANVEHICLEANDSHIPARMORSLEVEL3, UnitTypeId.ARMORY),
+            Step(RequiredUnitReady(UnitTypeId.ARMORY, 1), ActTech(UpgradeId.TERRANVEHICLEWEAPONSLEVEL1)),
+            ActTech(UpgradeId.TERRANVEHICLEANDSHIPARMORSLEVEL1),
+            ActTech(UpgradeId.TERRANVEHICLEWEAPONSLEVEL2),
+            ActTech(UpgradeId.TERRANVEHICLEANDSHIPARMORSLEVEL2),
+            ActTech(UpgradeId.TERRANVEHICLEWEAPONSLEVEL3),
+            ActTech(UpgradeId.TERRANVEHICLEANDSHIPARMORSLEVEL3),
         ]
 
         self.attack = PlanZoneAttack(40)

--- a/dummies/terran/rusty.py
+++ b/dummies/terran/rusty.py
@@ -67,7 +67,7 @@ class BuildTanks(BuildOrder):
             Step(None, GridBuilding(UnitTypeId.STARPORT, 1)),
             Step(None, GridBuilding(UnitTypeId.BARRACKS, 5)),
             Step(None, ActBuildAddon(UnitTypeId.BARRACKSTECHLAB, UnitTypeId.BARRACKS, 1)),
-            Step(None, ActTech(UpgradeId.SHIELDWALL, UnitTypeId.BARRACKSTECHLAB)),
+            Step(None, ActTech(UpgradeId.SHIELDWALL)),
             Step(None, ActBuildAddon(UnitTypeId.STARPORTREACTOR, UnitTypeId.STARPORT, 1)),
             Step(None, ActBuildAddon(UnitTypeId.BARRACKSREACTOR, UnitTypeId.BARRACKS, 3)),
             Step(None, ActExpand(3)),

--- a/dummies/terran/two_base_tanks.py
+++ b/dummies/terran/two_base_tanks.py
@@ -46,7 +46,7 @@ class TwoBaseTanks(KnowledgeBot):
             Step(RequiredSupply(45), GridBuilding(UnitTypeId.SUPPLYDEPOT, 8)),
             Step(None, GridBuilding(UnitTypeId.BARRACKS, 2)),
             Step(None, ActBuildAddon(UnitTypeId.BARRACKSTECHLAB, UnitTypeId.BARRACKS, 1)),
-            Step(None, ActTech(UpgradeId.SHIELDWALL, UnitTypeId.BARRACKSTECHLAB)),
+            Step(None, ActTech(UpgradeId.SHIELDWALL)),
             StepBuildGas(4),
             # BuildStep(None, GridBuilding(UnitTypeId.ARMORY, 1)),
             Step(RequiredSupply(75), GridBuilding(UnitTypeId.SUPPLYDEPOT, 10)),

--- a/dummies/zerg/lings.py
+++ b/dummies/zerg/lings.py
@@ -19,7 +19,7 @@ class LingSpeedBuild(BuildOrder):
 
         gas_related = [
             StepBuildGas(1, RequiredUnitExists(UnitTypeId.HATCHERY, 2)),
-            Step(None, ActTech(UpgradeId.ZERGLINGMOVEMENTSPEED, UnitTypeId.SPAWNINGPOOL), skip_until=RequiredGas(100)),
+            Step(None, ActTech(UpgradeId.ZERGLINGMOVEMENTSPEED), skip_until=RequiredGas(100)),
             Step(None, ActBuilding(UnitTypeId.ROACHWARREN, 1), skip_until=RequiredGas(100)),
 
         ]
@@ -69,7 +69,7 @@ class LingFloodBuild(BuildOrder):
 
         gas_related = [
             StepBuildGas(1, RequiredUnitExists(UnitTypeId.HATCHERY, 2)),
-            Step(None, ActTech(UpgradeId.ZERGLINGMOVEMENTSPEED, UnitTypeId.SPAWNINGPOOL), skip_until=RequiredGas(100)),
+            Step(None, ActTech(UpgradeId.ZERGLINGMOVEMENTSPEED), skip_until=RequiredGas(100)),
         ]
         buildings = [
             # 12 Pool

--- a/dummies/zerg/macro_roach.py
+++ b/dummies/zerg/macro_roach.py
@@ -25,15 +25,15 @@ class MacroRoach(KnowledgeBot):
         bsus = [
             Step(RequiredUnitReady(UnitTypeId.LAIR, 1), None),
             Step(RequiredUnitExists(UnitTypeId.ROACHWARREN, 1),
-                 ActTech(UpgradeId.GLIALRECONSTITUTION, UnitTypeId.ROACHWARREN)),
+                 ActTech(UpgradeId.GLIALRECONSTITUTION)),
         ]
 
         bsu = [
             Step(RequiredUnitExists(UnitTypeId.EVOLUTIONCHAMBER, 1),
-                 ActTech(UpgradeId.ZERGMISSILEWEAPONSLEVEL1, UnitTypeId.EVOLUTIONCHAMBER)),
-            Step(None, ActTech(UpgradeId.ZERGGROUNDARMORSLEVEL1, UnitTypeId.EVOLUTIONCHAMBER)),
-            Step(None, ActTech(UpgradeId.ZERGMISSILEWEAPONSLEVEL2, UnitTypeId.EVOLUTIONCHAMBER)),
-            Step(None, ActTech(UpgradeId.ZERGGROUNDARMORSLEVEL2, UnitTypeId.EVOLUTIONCHAMBER)),
+                 ActTech(UpgradeId.ZERGMISSILEWEAPONSLEVEL1)),
+            Step(None, ActTech(UpgradeId.ZERGGROUNDARMORSLEVEL1)),
+            Step(None, ActTech(UpgradeId.ZERGMISSILEWEAPONSLEVEL2)),
+            Step(None, ActTech(UpgradeId.ZERGGROUNDARMORSLEVEL2)),
         ]
 
         buildings = [

--- a/dummies/zerg/macro_zerg_v2.py
+++ b/dummies/zerg/macro_zerg_v2.py
@@ -36,28 +36,27 @@ class MacroBuild(BuildOrder):
         pool_and_tech = [
             Step(None, ActBuilding(UnitTypeId.SPAWNINGPOOL, 1)),
             StepBuildGas(2, None),
-            Step(None, ActTech(UpgradeId.ZERGLINGMOVEMENTSPEED, UnitTypeId.SPAWNINGPOOL)),
+            Step(None, ActTech(UpgradeId.ZERGLINGMOVEMENTSPEED)),
             Step(RequiredGas(120), ActBuilding(UnitTypeId.EVOLUTIONCHAMBER, 2)),
 
             Step(RequiredUnitExists(UnitTypeId.EVOLUTIONCHAMBER, 1),
-                 ActTech(UpgradeId.ZERGMELEEWEAPONSLEVEL1, UnitTypeId.EVOLUTIONCHAMBER)),
-            Step(None, ActTech(UpgradeId.ZERGGROUNDARMORSLEVEL1, UnitTypeId.EVOLUTIONCHAMBER)),
+                 ActTech(UpgradeId.ZERGMELEEWEAPONSLEVEL1)),
+            Step(None, ActTech(UpgradeId.ZERGGROUNDARMORSLEVEL1)),
             Step(None, MorphLair(), skip=RequiredUnitExists(UnitTypeId.HIVE, 1)),
             StepBuildGas(4, None),
-            Step(None, ActTech(UpgradeId.ZERGMELEEWEAPONSLEVEL2, UnitTypeId.EVOLUTIONCHAMBER)),
-            Step(None, ActTech(UpgradeId.ZERGGROUNDARMORSLEVEL2, UnitTypeId.EVOLUTIONCHAMBER)),
+            Step(None, ActTech(UpgradeId.ZERGMELEEWEAPONSLEVEL2)),
+            Step(None, ActTech(UpgradeId.ZERGGROUNDARMORSLEVEL2)),
             # Infestation pit required
             Step(None, ActBuilding(UnitTypeId.INFESTATIONPIT, 1)),
             Step(RequiredUnitReady(UnitTypeId.INFESTATIONPIT, 1), MorphHive()),
 
-            Step(RequiredUnitReady(UnitTypeId.HIVE, 1), ActTech(UpgradeId.ZERGLINGATTACKSPEED, UnitTypeId.SPAWNINGPOOL)),
+            Step(RequiredUnitReady(UnitTypeId.HIVE, 1), ActTech(UpgradeId.ZERGLINGATTACKSPEED)),
             StepBuildGas(6, None),
             Step(None, ActBuilding(UnitTypeId.ULTRALISKCAVERN, 1)),
-            Step(None, ActTech(UpgradeId.ZERGMELEEWEAPONSLEVEL3, UnitTypeId.EVOLUTIONCHAMBER)),
-            Step(None, ActTech(UpgradeId.ZERGGROUNDARMORSLEVEL3, UnitTypeId.EVOLUTIONCHAMBER)),
-            Step(None, ActTech(UpgradeId.CHITINOUSPLATING, UnitTypeId.ULTRALISKCAVERN)),
-            Step(None, ActTech(UpgradeId.ANABOLICSYNTHESIS, UnitTypeId.ULTRALISKCAVERN)),
-            # ULTRALISKCAVERNRESEARCH_EVOLVEANABOLICSYNTHESIS2
+            Step(None, ActTech(UpgradeId.ZERGMELEEWEAPONSLEVEL3)),
+            Step(None, ActTech(UpgradeId.ZERGGROUNDARMORSLEVEL3)),
+            Step(None, ActTech(UpgradeId.CHITINOUSPLATING)),
+            Step(None, ActTech(UpgradeId.ANABOLICSYNTHESIS)),
         ]
 
         super().__init__([

--- a/dummies/zerg/mutalisk.py
+++ b/dummies/zerg/mutalisk.py
@@ -16,7 +16,7 @@ class MutaliskBuild(BuildOrder):
 
         gas_related = [
             StepBuildGas(1, RequiredUnitExists(UnitTypeId.HATCHERY, 2)),
-            Step(None, ActTech(UpgradeId.ZERGLINGMOVEMENTSPEED, UnitTypeId.SPAWNINGPOOL), skip_until=RequiredGas(100)),
+            Step(None, ActTech(UpgradeId.ZERGLINGMOVEMENTSPEED), skip_until=RequiredGas(100)),
             Step(None, ActBuilding(UnitTypeId.ROACHWARREN, 1), skip_until=RequiredGas(100)),
             StepBuildGas(2, RequiredTime(4 * 60)),
             StepBuildGas(3, RequiredUnitExists(UnitTypeId.LAIR, 1)),
@@ -40,12 +40,12 @@ class MutaliskBuild(BuildOrder):
             MorphOverseer(1),
             Step(None, ZergUnit(UnitTypeId.QUEEN, 5)),
             Step(RequiredUnitExists(UnitTypeId.SPIRE), ActExpand(4)),
-            ActTech(UpgradeId.ZERGFLYERWEAPONSLEVEL1, UnitTypeId.SPIRE),
+            ActTech(UpgradeId.ZERGFLYERWEAPONSLEVEL1),
             Step(RequiredUnitExists(UnitTypeId.MUTALISK, 10, include_killed=True), ActBuilding(UnitTypeId.INFESTATIONPIT)),
             Step(RequiredUnitReady(UnitTypeId.INFESTATIONPIT), MorphHive()),
             MorphGreaterSpire(),
-            ActTech(UpgradeId.ZERGFLYERWEAPONSLEVEL2, UnitTypeId.GREATERSPIRE),
-            ActTech(UpgradeId.ZERGFLYERWEAPONSLEVEL3, UnitTypeId.GREATERSPIRE),
+            ActTech(UpgradeId.ZERGFLYERWEAPONSLEVEL2, UnitTypeId.GREATERSPIRE), # this can be researched from SPIRE as well.
+            ActTech(UpgradeId.ZERGFLYERWEAPONSLEVEL3, UnitTypeId.GREATERSPIRE), # python-sc2 thinks this can be researched from SPIRE
         ]
 
         high_tier = [

--- a/dummies/zerg/roach_hydra.py
+++ b/dummies/zerg/roach_hydra.py
@@ -15,7 +15,7 @@ class RoachHydraBuild(BuildOrder):
     def __init__(self):
 
         gas_related = [
-            Step(RequiredUnitExists(UnitTypeId.HATCHERY, 2), ActTech(UpgradeId.ZERGLINGMOVEMENTSPEED, UnitTypeId.SPAWNINGPOOL), skip_until=RequiredGas(100)),
+            Step(RequiredUnitExists(UnitTypeId.HATCHERY, 2), ActTech(UpgradeId.ZERGLINGMOVEMENTSPEED), skip_until=RequiredGas(100)),
             Step(None, ActBuilding(UnitTypeId.ROACHWARREN, 1), skip_until=RequiredGas(100)),
             StepBuildGas(2, RequiredTime(4 * 60), RequiredGas(100)),
             StepBuildGas(3, RequiredUnitExists(UnitTypeId.HYDRALISKDEN, 1), RequiredGas(50)),

--- a/dummies/zerg/worker_rush.py
+++ b/dummies/zerg/worker_rush.py
@@ -90,7 +90,7 @@ class LingFloodBuild(BuildOrder):
 
         gas_related = [
             StepBuildGas(1, RequiredUnitExists(UnitTypeId.HATCHERY, 2)),
-            Step(None, ActTech(UpgradeId.ZERGLINGMOVEMENTSPEED, UnitTypeId.SPAWNINGPOOL), skip_until=RequiredGas(100)),
+            Step(None, ActTech(UpgradeId.ZERGLINGMOVEMENTSPEED), skip_until=RequiredGas(100)),
         ]
         buildings = [
             # 12 Pool

--- a/sharpy/plans/acts/act_tech.py
+++ b/sharpy/plans/acts/act_tech.py
@@ -4,15 +4,31 @@ from sc2.ids.upgrade_id import UpgradeId
 from sc2.units import Units
 from .act_base import ActBase
 
+from sc2.dicts.upgrade_researched_from import UPGRADE_RESEARCHED_FROM
 
-# Act of researching a technology or upgrade
+
 class ActTech(ActBase):
-    def __init__(self, upgrade_type: UpgradeId, from_building: UnitTypeId):
+    """
+    Act for researching or upgrading a technology.
+    """
+    def __init__(self, upgrade_type: UpgradeId, from_building: UnitTypeId = None):
+        """
+        :param upgrade_type: Upgrade to research.
+        :param from_building: Optional building to research the upgrade from. This should no longer be needed,
+        as the building is available through an existing mapping file. The parameter is left for backwards
+        compatibility and possible SC2 version mismatches.
+        """
         assert upgrade_type is not None and isinstance(upgrade_type, UpgradeId)
-        assert from_building is not None and isinstance(from_building, UnitTypeId)
-
         self.upgrade_type = upgrade_type
-        self.from_building = from_building
+
+        if from_building is not None:
+            assert isinstance(from_building, UnitTypeId)
+            self.from_building = from_building
+        else:
+            # todo: take upgradeable buildings into account:
+            #   SPIRE & GREATERSPIRE
+            #   HATCHERY &  LAIR & HIVE
+            self.from_building = UPGRADE_RESEARCHED_FROM[self.upgrade_type]
 
         super().__init__()
 

--- a/sharpy/plans/build_order.py
+++ b/sharpy/plans/build_order.py
@@ -132,44 +132,44 @@ class BuildOrder(ActBase):
         return [
             # Armor
             Step(RequiredUnitReady(UnitTypeId.FORGE, 1),
-                 ActTech(UpgradeId.PROTOSSGROUNDARMORSLEVEL1, UnitTypeId.FORGE)),
+                 ActTech(UpgradeId.PROTOSSGROUNDARMORSLEVEL1)),
             Step(None,
-                 ActTech(UpgradeId.PROTOSSGROUNDARMORSLEVEL2, UnitTypeId.FORGE),
+                 ActTech(UpgradeId.PROTOSSGROUNDARMORSLEVEL2),
                  skip_until=RequiredAll([
                           RequiredUnitReady(UnitTypeId.TWILIGHTCOUNCIL, 1),
                           RequiredTechReady(UpgradeId.PROTOSSGROUNDARMORSLEVEL1, 1)
                       ])),
             Step(None,
-                 ActTech(UpgradeId.PROTOSSGROUNDARMORSLEVEL3, UnitTypeId.FORGE),
+                 ActTech(UpgradeId.PROTOSSGROUNDARMORSLEVEL3),
                  skip_until=RequiredAll(
                           [RequiredUnitReady(UnitTypeId.TWILIGHTCOUNCIL, 1),
                            RequiredTechReady(UpgradeId.PROTOSSGROUNDARMORSLEVEL2, 1)
                        ])),
             # Weapons
             Step(None,
-                 ActTech(UpgradeId.PROTOSSGROUNDWEAPONSLEVEL1, UnitTypeId.FORGE)),
+                 ActTech(UpgradeId.PROTOSSGROUNDWEAPONSLEVEL1)),
             Step(None,
-                 ActTech(UpgradeId.PROTOSSGROUNDWEAPONSLEVEL2, UnitTypeId.FORGE),
+                 ActTech(UpgradeId.PROTOSSGROUNDWEAPONSLEVEL2),
                  skip_until=RequiredAll(
                           [RequiredUnitReady(UnitTypeId.TWILIGHTCOUNCIL, 1),
                            RequiredTechReady(UpgradeId.PROTOSSGROUNDWEAPONSLEVEL1, 1)
                        ])),
             Step(None,
-                 ActTech(UpgradeId.PROTOSSGROUNDWEAPONSLEVEL3, UnitTypeId.FORGE),
+                 ActTech(UpgradeId.PROTOSSGROUNDWEAPONSLEVEL3),
                  skip_until=RequiredAll(
                           [RequiredUnitReady(UnitTypeId.TWILIGHTCOUNCIL, 1),
                            RequiredTechReady(UpgradeId.PROTOSSGROUNDWEAPONSLEVEL2, 1)]
                       )),
             # Shields
             Step(None,
-                 ActTech(UpgradeId.PROTOSSSHIELDSLEVEL1, UnitTypeId.FORGE)),
+                 ActTech(UpgradeId.PROTOSSSHIELDSLEVEL1)),
 
             Step(RequiredUnitReady(UnitTypeId.TWILIGHTCOUNCIL, 1), None),
 
             Step(RequiredTechReady(UpgradeId.PROTOSSSHIELDSLEVEL1, 1),
-                 ActTech(UpgradeId.PROTOSSSHIELDSLEVEL2, UnitTypeId.FORGE)),
+                 ActTech(UpgradeId.PROTOSSSHIELDSLEVEL2)),
             Step(RequiredTechReady(UpgradeId.PROTOSSSHIELDSLEVEL2, 1),
-                 ActTech(UpgradeId.PROTOSSSHIELDSLEVEL3, UnitTypeId.FORGE)),
+                 ActTech(UpgradeId.PROTOSSSHIELDSLEVEL3)),
         ]
 
     @property
@@ -177,15 +177,15 @@ class BuildOrder(ActBase):
         return [
             # Weapons
             Step(None,
-                 ActTech(UpgradeId.PROTOSSGROUNDWEAPONSLEVEL1, UnitTypeId.FORGE)),
+                 ActTech(UpgradeId.PROTOSSGROUNDWEAPONSLEVEL1)),
             Step(None,
-                 ActTech(UpgradeId.PROTOSSGROUNDWEAPONSLEVEL2, UnitTypeId.FORGE),
+                 ActTech(UpgradeId.PROTOSSGROUNDWEAPONSLEVEL2),
                  skip_until=RequiredAll(
                           [RequiredUnitReady(UnitTypeId.TWILIGHTCOUNCIL, 1),
                            RequiredTechReady(UpgradeId.PROTOSSGROUNDWEAPONSLEVEL1, 1)
                        ])),
             Step(None,
-                 ActTech(UpgradeId.PROTOSSGROUNDWEAPONSLEVEL3, UnitTypeId.FORGE),
+                 ActTech(UpgradeId.PROTOSSGROUNDWEAPONSLEVEL3),
                  skip_until=RequiredAll(
                           [RequiredUnitReady(UnitTypeId.TWILIGHTCOUNCIL, 1),
                            RequiredTechReady(UpgradeId.PROTOSSGROUNDWEAPONSLEVEL2, 1)
@@ -193,47 +193,47 @@ class BuildOrder(ActBase):
             
             # Armor
             Step(RequiredUnitReady(UnitTypeId.FORGE, 1),
-                 ActTech(UpgradeId.PROTOSSGROUNDARMORSLEVEL1, UnitTypeId.FORGE)),
+                 ActTech(UpgradeId.PROTOSSGROUNDARMORSLEVEL1)),
             Step(None,
-                 ActTech(UpgradeId.PROTOSSGROUNDARMORSLEVEL2, UnitTypeId.FORGE),
+                 ActTech(UpgradeId.PROTOSSGROUNDARMORSLEVEL2),
                  skip_until=RequiredAll(
                           [RequiredUnitReady(UnitTypeId.TWILIGHTCOUNCIL, 1),
                            RequiredTechReady(UpgradeId.PROTOSSGROUNDARMORSLEVEL1, 1)
                        ])),
             Step(None,
-                 ActTech(UpgradeId.PROTOSSGROUNDARMORSLEVEL3, UnitTypeId.FORGE),
+                 ActTech(UpgradeId.PROTOSSGROUNDARMORSLEVEL3),
                  skip_until=RequiredAll(
                           [RequiredUnitReady(UnitTypeId.TWILIGHTCOUNCIL, 1),
                            RequiredTechReady(UpgradeId.PROTOSSGROUNDARMORSLEVEL2, 1)
                        ])),
             # Shields
             Step(None,
-                 ActTech(UpgradeId.PROTOSSSHIELDSLEVEL1, UnitTypeId.FORGE)),
+                 ActTech(UpgradeId.PROTOSSSHIELDSLEVEL1)),
 
             Step(RequiredUnitReady(UnitTypeId.TWILIGHTCOUNCIL, 1), None),
 
             Step(RequiredTechReady(UpgradeId.PROTOSSSHIELDSLEVEL1, 1),
-                 ActTech(UpgradeId.PROTOSSSHIELDSLEVEL2, UnitTypeId.FORGE)),
+                 ActTech(UpgradeId.PROTOSSSHIELDSLEVEL2)),
             Step(RequiredTechReady(UpgradeId.PROTOSSSHIELDSLEVEL2, 1),
-                 ActTech(UpgradeId.PROTOSSSHIELDSLEVEL3, UnitTypeId.FORGE)),
+                 ActTech(UpgradeId.PROTOSSSHIELDSLEVEL3)),
         ]
 
     @property
     def air_upgrades_all(self) -> List[Step]:
         return [
             Step(RequiredUnitReady(UnitTypeId.CYBERNETICSCORE, 1),
-                 ActTech(UpgradeId.PROTOSSAIRWEAPONSLEVEL1, UnitTypeId.CYBERNETICSCORE)),
+                 ActTech(UpgradeId.PROTOSSAIRWEAPONSLEVEL1)),
             Step(None,
-                 ActTech(UpgradeId.PROTOSSAIRARMORSLEVEL1, UnitTypeId.CYBERNETICSCORE)),
+                 ActTech(UpgradeId.PROTOSSAIRARMORSLEVEL1)),
             Step(RequiredUnitReady(UnitTypeId.FLEETBEACON, 1), None),
             Step(RequiredTechReady(UpgradeId.PROTOSSAIRWEAPONSLEVEL1),
-                 ActTech(UpgradeId.PROTOSSAIRWEAPONSLEVEL2, UnitTypeId.CYBERNETICSCORE)),
+                 ActTech(UpgradeId.PROTOSSAIRWEAPONSLEVEL2)),
             Step(RequiredTechReady(UpgradeId.PROTOSSAIRARMORSLEVEL1),
-                 ActTech(UpgradeId.PROTOSSAIRARMORSLEVEL2, UnitTypeId.CYBERNETICSCORE)),
+                 ActTech(UpgradeId.PROTOSSAIRARMORSLEVEL2)),
             Step(RequiredTechReady(UpgradeId.PROTOSSAIRWEAPONSLEVEL2),
-                 ActTech(UpgradeId.PROTOSSAIRWEAPONSLEVEL3, UnitTypeId.CYBERNETICSCORE)),
+                 ActTech(UpgradeId.PROTOSSAIRWEAPONSLEVEL3)),
             Step(RequiredTechReady(UpgradeId.PROTOSSAIRARMORSLEVEL2),
-                 ActTech(UpgradeId.PROTOSSAIRARMORSLEVEL3, UnitTypeId.CYBERNETICSCORE)),
+                 ActTech(UpgradeId.PROTOSSAIRARMORSLEVEL3)),
         ]
 
     async def start(self, knowledge: 'Knowledge'):


### PR DESCRIPTION
from_building parameter can still be provided for backwards compatibility and possible SC2 version mismatches.

There may be some problems with eg. upgrades from SPIRE and GREATERSPIRE. But again, if problems occur, the building type can always be explicitly specified.