### PR TITLE
Shorten list definitions

### DIFF
--- a/dummies/protoss/adept_allin.py
+++ b/dummies/protoss/adept_allin.py
@@ -33,10 +33,10 @@ class AdeptRush(KnowledgeBot):
     async def create_plan(self) -> BuildOrder:
         number = random.randint(10, 15)
         attack = TheAttack(number + 1)
-        return BuildOrder([
+        return BuildOrder(
             Step(None, ChronoUnitProduction(UnitTypeId.PROBE, UnitTypeId.NEXUS),
                  skip=RequiredUnitExists(UnitTypeId.PROBE, 20, include_pending=True), skip_until=RequiredUnitExists(UnitTypeId.ASSIMILATOR, 1)),
-            SequentialList([
+            SequentialList(
                 GridBuilding(UnitTypeId.PYLON, 1),
                 ActUnit(UnitTypeId.PROBE, UnitTypeId.NEXUS, 14),
                 GridBuilding(UnitTypeId.GATEWAY, 1),
@@ -47,36 +47,33 @@ class AdeptRush(KnowledgeBot):
                 ActUnit(UnitTypeId.PROBE, UnitTypeId.NEXUS, 20),
                 ArtosisPylon(2),
                 BuildOrder(
-                    [
                         AutoPylon(),
                         SequentialList(
-                        [
                             Step(None, GridBuilding(UnitTypeId.CYBERNETICSCORE, 1), skip_until=RequiredUnitReady(UnitTypeId.GATEWAY, 1)),
                             Step(RequiredUnitReady(UnitTypeId.CYBERNETICSCORE, 1), GateUnit(UnitTypeId.ADEPT, 2, only_once=True)),
                             ActTech(UpgradeId.WARPGATERESEARCH),
                             GateUnit(UnitTypeId.ADEPT, 100)
-                        ]),
+                        ),
                         Step(RequiredUnitExists(UnitTypeId.CYBERNETICSCORE, 1), GridBuilding(UnitTypeId.GATEWAY, 4),
                              skip_until=RequiredMinerals(200)),
 
                         Step(None, ProtossUnit(UnitTypeId.ZEALOT, 100),
                              skip=RequiredGas(25),
                              skip_until=RequiredMinerals(200)),
-                    ]),
+                    ),
 
 
-            ]),
+            ),
             SequentialList(
-                [
-                    PlanZoneDefense(),
-                    RestorePower(),
-                    PlanDistributeWorkers(),
-                    PlanZoneGather(),
-                    DoubleAdeptScout(number),
-                    attack,
-                    PlanFinishEnemy(),
-                ])
-        ])
+                PlanZoneDefense(),
+                RestorePower(),
+                PlanDistributeWorkers(),
+                PlanZoneGather(),
+                DoubleAdeptScout(number),
+                attack,
+                PlanFinishEnemy(),
+            )
+        )
 
 
 class LadderBot(AdeptRush):

--- a/dummies/protoss/cannon_rush.py
+++ b/dummies/protoss/cannon_rush.py
@@ -205,16 +205,15 @@ class CannonRush(KnowledgeBot):
         else:
            cannon_rush = self.cannon_rush()
 
-        return BuildOrder([
+        return BuildOrder(
             Step(None, ChronoUnitProduction(UnitTypeId.PROBE, UnitTypeId.NEXUS),
                  skip=RequiredUnitExists(UnitTypeId.PROBE, 16), skip_until=RequiredUnitReady(UnitTypeId.PYLON, 1)),
             ChronoAnyTech(0),
-            SequentialList([
+            SequentialList(
                 ActUnit(UnitTypeId.PROBE, UnitTypeId.NEXUS, 13),
                 GridBuilding(UnitTypeId.PYLON, 1),
                 Step(None, cannon_rush, skip=rush_killed),
                 BuildOrder(
-                    [
                         [
                             ActExpand(2),
                             ProtossUnit(UnitTypeId.PROBE, 30),
@@ -243,19 +242,18 @@ class CannonRush(KnowledgeBot):
                             Step(RequiredUnitReady(UnitTypeId.CYBERNETICSCORE, 1), GridBuilding(UnitTypeId.GATEWAY, 7)),
                             StepBuildGas(4, skip=RequiredGas(200)),
                         ]
-                    ])
+                    )
 
-            ]),
+            ),
             SequentialList(
-                [
                     PlanCancelBuilding(),
                     PlanZoneDefense(),
                     PlanDistributeWorkers(),
                     PlanZoneGather(),
                     PlanZoneAttack(6),
                     PlanFinishEnemy(),
-                ])
-        ])
+            )
+        )
 
     def cannon_contain(self) -> ActBase:
         self.knowledge.print(f"Cannon contain", "Build")

--- a/dummies/protoss/dark_templar_rush.py
+++ b/dummies/protoss/dark_templar_rush.py
@@ -124,10 +124,10 @@ class DarkTemplarRush(KnowledgeBot):
             PlanFinishEnemy(),
         ]
 
-        return BuildOrder([
+        return BuildOrder(
             build_order,
             tactics
-        ])
+        )
 
 
 class LadderBot(DarkTemplarRush):

--- a/dummies/protoss/disruptor.py
+++ b/dummies/protoss/disruptor.py
@@ -12,7 +12,7 @@ from sharpy.plans.tactics.protoss import *
 
 class DistruptorBuild(BuildOrder):
     def __init__(self):
-        build = BuildOrder([
+        build = BuildOrder(
             Step(RequiredUnitReady(UnitTypeId.PYLON), ChronoUnitProduction(UnitTypeId.PROBE, UnitTypeId.NEXUS),
                  skip=RequiredUnitExists(UnitTypeId.PROBE, 19)),
             Step(None, ChronoUnitProduction(UnitTypeId.IMMORTAL, UnitTypeId.ROBOTICSFACILITY),
@@ -22,12 +22,12 @@ class DistruptorBuild(BuildOrder):
             Step(None, ChronoUnitProduction(UnitTypeId.DISRUPTOR, UnitTypeId.ROBOTICSFACILITY),
                  skip=RequiredUnitExists(UnitTypeId.DISRUPTOR, 1, include_killed=True)),
 
-            SequentialList([
+            SequentialList(
                 ProtossUnit(UnitTypeId.PROBE, 16 + 6),  # One base
                 Step(RequiredUnitExists(UnitTypeId.NEXUS, 2), ProtossUnit(UnitTypeId.PROBE, 44))
-            ]),
+            ),
             Step(RequiredUnitReady(UnitTypeId.PYLON, 1), AutoPylon()),
-            SequentialList([
+            SequentialList(
                 GridBuilding(UnitTypeId.PYLON, 1),
                 GridBuilding(UnitTypeId.GATEWAY, 2, priority=True),
                 StepBuildGas(2),
@@ -38,18 +38,18 @@ class DistruptorBuild(BuildOrder):
                 Step(RequiredUnitExists(UnitTypeId.DISRUPTOR, 1, include_killed=True, include_not_ready=False),
                      ActExpand(2)),
                 StepBuildGas(4),
-            ]),
-            BuildOrder([
+            ),
+            BuildOrder(
                 ProtossUnit(UnitTypeId.IMMORTAL, 1, priority=True, only_once=True),
                 ProtossUnit(UnitTypeId.OBSERVER, 1, priority=True),
                 ProtossUnit(UnitTypeId.DISRUPTOR, 4, priority=True),
                 ProtossUnit(UnitTypeId.STALKER),
-                SequentialList([
+                SequentialList(
                     Step(RequiredMinerals(300), GridBuilding(UnitTypeId.GATEWAY, 3, priority=True)),
                     Step(RequiredUnitReady(UnitTypeId.NEXUS, 2), GridBuilding(UnitTypeId.GATEWAY, 6, priority=True))
-                ])
-            ])
-        ])
+                )
+            )
+        )
 
         tactics = [
             PlanCancelBuilding(),
@@ -63,7 +63,7 @@ class DistruptorBuild(BuildOrder):
             PlanFinishEnemy()
         ]
 
-        super().__init__([build, tactics])
+        super().__init__(build, tactics)
 
 
 class SharpSphereBot(KnowledgeBot):

--- a/dummies/protoss/gate4.py
+++ b/dummies/protoss/gate4.py
@@ -15,11 +15,11 @@ class Stalkers4Gate(KnowledgeBot):
 
     async def create_plan(self) -> BuildOrder:
         attack = PlanZoneAttack(6)
-        return BuildOrder([
+        return BuildOrder(
             Step(None, ChronoUnitProduction(UnitTypeId.PROBE, UnitTypeId.NEXUS),
                  skip=RequiredUnitExists(UnitTypeId.PROBE, 20, include_pending=True), skip_until=RequiredUnitExists(UnitTypeId.ASSIMILATOR, 1)),
             ChronoTech(AbilityId.RESEARCH_BLINK, UnitTypeId.TWILIGHTCOUNCIL),
-            SequentialList([
+            SequentialList(
                 ActUnit(UnitTypeId.PROBE, UnitTypeId.NEXUS, 14),
                 GridBuilding(UnitTypeId.PYLON, 1),
                 ActUnit(UnitTypeId.PROBE, UnitTypeId.NEXUS, 16),
@@ -29,35 +29,32 @@ class Stalkers4Gate(KnowledgeBot):
                 ActUnit(UnitTypeId.PROBE, UnitTypeId.NEXUS, 19),
                 GridBuilding(UnitTypeId.GATEWAY, 2),
                 BuildOrder(
-                    [
                         AutoPylon(),
                         ActUnit(UnitTypeId.PROBE, UnitTypeId.NEXUS, 22),
                         SequentialList(
-                        [
                             Step(RequiredUnitReady(UnitTypeId.CYBERNETICSCORE, 1), GridBuilding(UnitTypeId.TWILIGHTCOUNCIL, 1)),
                             Step(RequiredUnitReady(UnitTypeId.TWILIGHTCOUNCIL, 1), ActTech(UpgradeId.BLINKTECH)),
-                        ]),
+                        ),
                         SequentialList(
-                        [
                             Step(None, GridBuilding(UnitTypeId.CYBERNETICSCORE, 1), skip_until=RequiredUnitReady(UnitTypeId.GATEWAY, 1)),
                             Step(RequiredUnitReady(UnitTypeId.CYBERNETICSCORE, 1), GateUnit(UnitTypeId.ADEPT, 2, only_once=True)),
                             ActTech(UpgradeId.WARPGATERESEARCH),
                             GateUnit(UnitTypeId.STALKER, 100)
-                        ]),
+                        ),
                         Step(RequiredUnitExists(UnitTypeId.CYBERNETICSCORE, 1), GridBuilding(UnitTypeId.GATEWAY, 4))
-                    ]),
+                    ),
 
-            ]),
+            ),
             SequentialList(
-                [
+
                     PlanZoneDefense(),
                     RestorePower(),
                     PlanDistributeWorkers(),
                     PlanZoneGather(),
                     Step(RequiredTechReady(UpgradeId.BLINKTECH, 0.9), attack),
                     PlanFinishEnemy(),
-                ])
-        ])
+                )
+        )
 
 
 class LadderBot(Stalkers4Gate):

--- a/dummies/protoss/macro_stalkers.py
+++ b/dummies/protoss/macro_stalkers.py
@@ -15,10 +15,10 @@ class MacroStalkers(KnowledgeBot):
         super().__init__("Sharp Spiders")
 
     async def create_plan(self) -> BuildOrder:
-        return BuildOrder([
+        return BuildOrder(
             Step(None, ChronoUnitProduction(UnitTypeId.PROBE, UnitTypeId.NEXUS),
                  skip=RequiredUnitExists(UnitTypeId.PROBE, 40, include_pending=True), skip_until=RequiredUnitExists(UnitTypeId.ASSIMILATOR, 1)),
-            SequentialList([
+            SequentialList(
                 ActUnit(UnitTypeId.PROBE, UnitTypeId.NEXUS, 14),
                 GridBuilding(UnitTypeId.PYLON, 1),
                 ActUnit(UnitTypeId.PROBE, UnitTypeId.NEXUS, 16),
@@ -32,14 +32,13 @@ class MacroStalkers(KnowledgeBot):
                 ActUnit(UnitTypeId.PROBE, UnitTypeId.NEXUS, 22),
                 GridBuilding(UnitTypeId.PYLON, 1),
                 BuildOrder(
+                    AutoPylon(),
+                    ActTech(UpgradeId.WARPGATERESEARCH),
                     [
-                        AutoPylon(),
-                        ActTech(UpgradeId.WARPGATERESEARCH),
-                        [
-                            ActUnit(UnitTypeId.PROBE, UnitTypeId.NEXUS, 22),
-                            Step(RequiredUnitExists(UnitTypeId.NEXUS, 2), ActUnit(UnitTypeId.PROBE, UnitTypeId.NEXUS, 44)),
-                            StepBuildGas(3,skip=RequiredGas(300))
-                        ],
+                        ActUnit(UnitTypeId.PROBE, UnitTypeId.NEXUS, 22),
+                        Step(RequiredUnitExists(UnitTypeId.NEXUS, 2), ActUnit(UnitTypeId.PROBE, UnitTypeId.NEXUS, 44)),
+                        StepBuildGas(3,skip=RequiredGas(300))
+                    ],
                     [
                         GateUnit(UnitTypeId.STALKER, 100)
                     ],
@@ -47,17 +46,17 @@ class MacroStalkers(KnowledgeBot):
                         GridBuilding(UnitTypeId.GATEWAY, 7),
                         StepBuildGas(4, skip=RequiredGas(200)),
                     ]
-                ])
-            ]),
-            SequentialList([
+                )
+            ),
+            SequentialList(
                 PlanZoneDefense(),
                 RestorePower(),
                 PlanDistributeWorkers(),
                 PlanZoneGather(),
                 Step(RequiredUnitReady(UnitTypeId.GATEWAY, 4), PlanZoneAttack(4)),
                 PlanFinishEnemy(),
-            ])
-        ])
+            )
+        )
 
 
 class LadderBot(MacroStalkers):

--- a/dummies/protoss/one_base_tempests.py
+++ b/dummies/protoss/one_base_tempests.py
@@ -18,7 +18,7 @@ class OneBaseTempests(KnowledgeBot):
         return BuildOrder([
             ChronoUnitProduction(UnitTypeId.TEMPEST, UnitTypeId.STARGATE),
 
-            SequentialList([
+            SequentialList(
                 ProtossUnit(UnitTypeId.PROBE, 14),
                 GridBuilding(UnitTypeId.PYLON, 1),
                 ProtossUnit(UnitTypeId.PROBE, 15),
@@ -30,34 +30,31 @@ class OneBaseTempests(KnowledgeBot):
                 GridBuilding(UnitTypeId.CYBERNETICSCORE, 1),
                 ProtossUnit(UnitTypeId.PROBE, 22),
                 BuildOrder(
+                    AutoPylon(),
+                    SequentialList(
+                            GridBuilding(UnitTypeId.STARGATE, 1),
+                            Step(RequiredUnitReady(UnitTypeId.STARGATE, 1),
+                                 GridBuilding(UnitTypeId.FLEETBEACON, 1))
+                        ),
                     [
-                        AutoPylon(),
-                        SequentialList(
-                            [
-                                GridBuilding(UnitTypeId.STARGATE, 1),
-                                Step(RequiredUnitReady(UnitTypeId.STARGATE, 1),
-                                     GridBuilding(UnitTypeId.FLEETBEACON, 1))
-                            ]),
-                        [
-                            ProtossUnit(UnitTypeId.TEMPEST, 100, priority=True)
-                        ],
-                        [
-                            Step(RequiredUnitExists(UnitTypeId.FLEETBEACON, 1),
-                                 GridBuilding(UnitTypeId.STARGATE, 2))
-                        ],
-                    ]),
+                        ProtossUnit(UnitTypeId.TEMPEST, 100, priority=True)
+                    ],
+                    [
+                        Step(RequiredUnitExists(UnitTypeId.FLEETBEACON, 1),
+                             GridBuilding(UnitTypeId.STARGATE, 2))
+                    ],
+                ),
 
-            ]),
+            ),
             ActDefensiveCannons(4, 2, 0),
             SequentialList(
-                [
-                    PlanZoneDefense(),
-                    RestorePower(),
-                    PlanDistributeWorkers(),
-                    PlanZoneGather(),
-                    Step(RequiredUnitExists(UnitTypeId.TEMPEST, 1, include_killed=True), attack),
-                    PlanFinishEnemy(),
-                ])
+                PlanZoneDefense(),
+                RestorePower(),
+                PlanDistributeWorkers(),
+                PlanZoneGather(),
+                Step(RequiredUnitExists(UnitTypeId.TEMPEST, 1, include_killed=True), attack),
+                PlanFinishEnemy(),
+            )
         ])
 
 

--- a/dummies/protoss/protoss_random.py
+++ b/dummies/protoss/protoss_random.py
@@ -1,6 +1,6 @@
 import random
 
-val = random.randint(0, 7)
+val = random.randint(0, 9)
 
 if val == 0:
     from .adept_allin import LadderBot
@@ -18,6 +18,9 @@ elif val == 6:
     from .robo import LadderBot
 elif val == 7:
     from .voidray import LadderBot
-
+elif val == 8:
+    from .one_base_tempests import LadderBot
+elif val == 9:
+    from .disruptor import LadderBot
 class RandomProtossBot(LadderBot):
     pass

--- a/dummies/protoss/proxy_zealot_rush.py
+++ b/dummies/protoss/proxy_zealot_rush.py
@@ -117,14 +117,14 @@ class ProxyZealotRushBot(KnowledgeBot):
         attack = PlanZoneAttack(7)
         attack.retreat_multiplier = 0.3
         # attack.attack_started = True
-        backup = BuildOrder([
+        backup = BuildOrder(
             Step(None, ChronoUnitProduction(UnitTypeId.PROBE, UnitTypeId.NEXUS),
                  skip=RequiredUnitExists(UnitTypeId.PROBE, 30, include_pending=True),
                  skip_until=RequiredUnitExists(UnitTypeId.ASSIMILATOR, 1)),
             ChronoUnitProduction(UnitTypeId.VOIDRAY, UnitTypeId.STARGATE),
                 ActDefensiveCannons(0, 1),
 
-            SequentialList([
+            SequentialList(
                 ActUnit(UnitTypeId.PROBE, UnitTypeId.NEXUS, 14),
                 GridBuilding(UnitTypeId.PYLON, 1),
                 StepBuildGas(1),
@@ -137,45 +137,43 @@ class ProxyZealotRushBot(KnowledgeBot):
                 StepBuildGas(2),
                 GridBuilding(UnitTypeId.PYLON, 1),
                 BuildOrder(
+                    AutoPylon(),
+                    GateUnit(UnitTypeId.STALKER, 2, priority=True),
+                    ActTech(UpgradeId.WARPGATERESEARCH),
                     [
-                        AutoPylon(),
-                        GateUnit(UnitTypeId.STALKER, 2, priority=True),
-                        ActTech(UpgradeId.WARPGATERESEARCH),
-                        [
-                            ActUnit(UnitTypeId.PROBE, UnitTypeId.NEXUS, 22),
-                            Step(RequiredUnitExists(UnitTypeId.NEXUS, 2),
-                                 ActUnit(UnitTypeId.PROBE, UnitTypeId.NEXUS, 44)),
-                            StepBuildGas(3, skip=RequiredGas(300)),
-                            Step(RequiredUnitExists(UnitTypeId.NEXUS, 3),
-                                 ActUnit(UnitTypeId.PROBE, UnitTypeId.NEXUS, 56)),
-                            StepBuildGas(5, skip=RequiredGas(200)),
-                        ],
-                        SequentialList(
-                            [
-                                Step(RequiredUnitReady(UnitTypeId.CYBERNETICSCORE, 1),
-                                     GridBuilding(UnitTypeId.TWILIGHTCOUNCIL, 1)),
-                                GridBuilding(UnitTypeId.STARGATE, 1),
-                                Step(RequiredUnitReady(UnitTypeId.TWILIGHTCOUNCIL, 1),
-                                     ActTech(UpgradeId.CHARGE)),
-                                Step(RequiredUnitReady(UnitTypeId.TWILIGHTCOUNCIL, 1),
-                                     ActTech(UpgradeId.ADEPTPIERCINGATTACK)),
-                            ]),
-                        [
-                            ActUnit(UnitTypeId.VOIDRAY, UnitTypeId.STARGATE, 20, priority=True)
-                        ],
-                        Step(RequiredTime(60 * 5), ActExpand(3)),
-                        [
-                            GateUnit(UnitTypeId.STALKER, 30)
-                        ],
-                        [
-                            GridBuilding(UnitTypeId.GATEWAY, 4),
-                            StepBuildGas(4, skip=RequiredGas(200)),
-                            GridBuilding(UnitTypeId.STARGATE, 2),
-                        ]
-                    ])
-            ]),
+                        ActUnit(UnitTypeId.PROBE, UnitTypeId.NEXUS, 22),
+                        Step(RequiredUnitExists(UnitTypeId.NEXUS, 2),
+                             ActUnit(UnitTypeId.PROBE, UnitTypeId.NEXUS, 44)),
+                        StepBuildGas(3, skip=RequiredGas(300)),
+                        Step(RequiredUnitExists(UnitTypeId.NEXUS, 3),
+                             ActUnit(UnitTypeId.PROBE, UnitTypeId.NEXUS, 56)),
+                        StepBuildGas(5, skip=RequiredGas(200)),
+                    ],
+                    SequentialList(
+                        Step(RequiredUnitReady(UnitTypeId.CYBERNETICSCORE, 1),
+                             GridBuilding(UnitTypeId.TWILIGHTCOUNCIL, 1)),
+                        GridBuilding(UnitTypeId.STARGATE, 1),
+                        Step(RequiredUnitReady(UnitTypeId.TWILIGHTCOUNCIL, 1),
+                             ActTech(UpgradeId.CHARGE)),
+                        Step(RequiredUnitReady(UnitTypeId.TWILIGHTCOUNCIL, 1),
+                             ActTech(UpgradeId.ADEPTPIERCINGATTACK)),
+                    ),
+                    [
+                        ActUnit(UnitTypeId.VOIDRAY, UnitTypeId.STARGATE, 20, priority=True)
+                    ],
+                    Step(RequiredTime(60 * 5), ActExpand(3)),
+                    [
+                        GateUnit(UnitTypeId.STALKER, 30)
+                    ],
+                    [
+                        GridBuilding(UnitTypeId.GATEWAY, 4),
+                        StepBuildGas(4, skip=RequiredGas(200)),
+                        GridBuilding(UnitTypeId.STARGATE, 2),
+                    ]
+                )
+            ),
 
-        ])
+        )
         proxy_zealots = ProxyZealots()
 
         return BuildOrder([

--- a/dummies/protoss/robo.py
+++ b/dummies/protoss/robo.py
@@ -24,12 +24,12 @@ class MacroRobo(KnowledgeBot):
 
     async def create_plan(self) -> BuildOrder:
         attack = TheAttack(4)
-        return BuildOrder([
+        return BuildOrder(
             Step(None, ChronoUnitProduction(UnitTypeId.PROBE, UnitTypeId.NEXUS),
                  skip=RequiredUnitExists(UnitTypeId.PROBE, 30, include_pending=True), skip_until=RequiredUnitExists(UnitTypeId.ASSIMILATOR, 1)),
             ChronoUnitProduction(UnitTypeId.IMMORTAL, UnitTypeId.ROBOTICSFACILITY),
 
-            SequentialList([
+            SequentialList(
                 ActUnit(UnitTypeId.PROBE, UnitTypeId.NEXUS, 14),
                 GridBuilding(UnitTypeId.PYLON, 1),
                 ActUnit(UnitTypeId.PROBE, UnitTypeId.NEXUS, 16),
@@ -43,7 +43,6 @@ class MacroRobo(KnowledgeBot):
                 ActUnit(UnitTypeId.PROBE, UnitTypeId.NEXUS, 22),
                 GridBuilding(UnitTypeId.PYLON, 1),
                 BuildOrder(
-                [
                     AutoPylon(),
                     GateUnit(UnitTypeId.STALKER, 2, priority=True),
                     ActTech(UpgradeId.WARPGATERESEARCH),
@@ -76,9 +75,9 @@ class MacroRobo(KnowledgeBot):
                         StepBuildGas(4, skip=RequiredGas(200)),
                         GridBuilding(UnitTypeId.ROBOTICSFACILITY, 2),
                     ]
-                ])
-            ]),
-            SequentialList([
+                )
+            ),
+            SequentialList(
                 PlanCancelBuilding(),
                 PlanHeatObserver(),
                 PlanZoneDefense(),
@@ -87,8 +86,8 @@ class MacroRobo(KnowledgeBot):
                 PlanZoneGather(),
                 Step(RequiredUnitReady(UnitTypeId.IMMORTAL, 3), attack),
                 PlanFinishEnemy(),
-            ])
-        ])
+            )
+        )
 
 
 class LadderBot(MacroRobo):

--- a/dummies/protoss/voidray.py
+++ b/dummies/protoss/voidray.py
@@ -23,12 +23,12 @@ class MacroVoidray(KnowledgeBot):
 
     async def create_plan(self) -> BuildOrder:
         attack = TheAttack(4)
-        return BuildOrder([
+        return BuildOrder(
             Step(None, ChronoUnitProduction(UnitTypeId.PROBE, UnitTypeId.NEXUS),
                  skip=RequiredUnitExists(UnitTypeId.PROBE, 30, include_pending=True), skip_until=RequiredUnitExists(UnitTypeId.ASSIMILATOR, 1)),
             ChronoUnitProduction(UnitTypeId.VOIDRAY, UnitTypeId.STARGATE),
             
-            SequentialList([
+            SequentialList(
                 ProtossUnit(UnitTypeId.PROBE, 14),
                 GridBuilding(UnitTypeId.PYLON, 1),
                 ProtossUnit(UnitTypeId.PROBE, 16),
@@ -42,7 +42,6 @@ class MacroVoidray(KnowledgeBot):
                 StepBuildGas(2),
                 GridBuilding(UnitTypeId.PYLON, 1),
                 BuildOrder(
-                [
                     AutoPylon(),
                     GateUnit(UnitTypeId.STALKER, 2, priority=True),
                     ActTech(UpgradeId.WARPGATERESEARCH),
@@ -80,18 +79,18 @@ class MacroVoidray(KnowledgeBot):
                         StepBuildGas(4, skip=RequiredGas(200)),
                         GridBuilding(UnitTypeId.STARGATE, 2),
                     ]
-                ])
-            ]),
+                )
+            ),
             SequentialList(
-            [
+
                 PlanZoneDefense(),
                 RestorePower(),
                 PlanDistributeWorkers(),
                 PlanZoneGather(),
                 Step(RequiredUnitReady(UnitTypeId.VOIDRAY, 3), attack),
                 PlanFinishEnemy(),
-            ])
-        ])
+            )
+        )
 
 
 class LadderBot(MacroVoidray):

--- a/dummies/terran/banshees.py
+++ b/dummies/terran/banshees.py
@@ -46,7 +46,7 @@ class Banshees(KnowledgeBot):
             PlanFinishEnemy(),
         ]
 
-        return BuildOrder([
+        return BuildOrder(
             AutoDepot(),
             Step(None, MorphOrbitals(), skip_until=RequiredUnitReady(UnitTypeId.BARRACKS, 1)),
             [
@@ -94,7 +94,7 @@ class Banshees(KnowledgeBot):
             ActUnit(UnitTypeId.SIEGETANK, UnitTypeId.FACTORY, 10),
             ActUnit(UnitTypeId.MARINE, UnitTypeId.BARRACKS, 50),
             SequentialList(tactics)
-        ])
+        )
 
 
 class LadderBot(Banshees):

--- a/dummies/terran/battle_cruisers.py
+++ b/dummies/terran/battle_cruisers.py
@@ -66,7 +66,7 @@ class BattleCruisers(KnowledgeBot):
             PlanFinishEnemy(),
         ]
 
-        return BuildOrder([
+        return BuildOrder(
             empty.depots,
             Step(None, MorphOrbitals(), skip_until=RequiredUnitReady(UnitTypeId.BARRACKS, 1)),
             [
@@ -109,13 +109,13 @@ class BattleCruisers(KnowledgeBot):
                                   RequiredEnemyUnitExistsAfter(UnitTypeId.BANSHEE)]), None),
                 Step(RequiredUnitReady(UnitTypeId.STARPORT, 1), ActUnit(UnitTypeId.RAVEN, UnitTypeId.STARPORT, 2, priority=True)),
             ],
-            Step(None, SequentialList([
+            Step(None, SequentialList(
                 ActUnit(UnitTypeId.BATTLECRUISER, UnitTypeId.STARPORT, 20, priority=True)
-            ]), skip_until=RequiredUnitReady(UnitTypeId.FUSIONCORE, 1)),
+            ), skip_until=RequiredUnitReady(UnitTypeId.FUSIONCORE, 1)),
             ActUnit(UnitTypeId.SIEGETANK, UnitTypeId.FACTORY, 10),
             ActUnit(UnitTypeId.MARINE, UnitTypeId.BARRACKS, 50),
             SequentialList(tactics)
-        ])
+        )
 
 
 class LadderBot(BattleCruisers):

--- a/dummies/terran/cyclones.py
+++ b/dummies/terran/cyclones.py
@@ -84,7 +84,7 @@ class CycloneBot(KnowledgeBot):
             PlanFinishEnemy(),
         ]
 
-        return BuildOrder([
+        return BuildOrder(
             Step(RequiredUnitExists(UnitTypeId.BARRACKS, 1), SequentialList(self.depots)),
             [
                 Step(RequiredUnitExists(UnitTypeId.COMMANDCENTER, 2), MorphOrbitals(3), skip_until=RequiredUnitReady(UnitTypeId.BARRACKS, 1)),
@@ -109,7 +109,7 @@ class CycloneBot(KnowledgeBot):
 
             buildings,
             SequentialList(tactics)
-        ])
+        )
 
     @property
     def depots(self) -> List[Step]:

--- a/dummies/terran/marine_rush.py
+++ b/dummies/terran/marine_rush.py
@@ -122,7 +122,7 @@ class MarineRushBot(KnowledgeBot):
             PlanFinishEnemy(),
         ]
 
-        return BuildOrder([
+        return BuildOrder(
             empty.depots,
             Step(None, MorphOrbitals(), skip_until=RequiredUnitReady(UnitTypeId.BARRACKS, 1)),
             [
@@ -132,7 +132,7 @@ class MarineRushBot(KnowledgeBot):
 
             ActUnit(UnitTypeId.MARINE, UnitTypeId.BARRACKS, 200),
             SequentialList(tactics)
-        ])
+        )
 
 
 class LadderBot(MarineRushBot):

--- a/dummies/terran/one_base_turtle.py
+++ b/dummies/terran/one_base_turtle.py
@@ -76,10 +76,10 @@ class OneBaseTurtle(KnowledgeBot):
             Step(RequiredUnitExists(UnitTypeId.MARINE, 18, include_killed=True), attack),
             PlanFinishEnemy(),
         ]
-        return BuildOrder([
+        return BuildOrder(
             build_order,
             tactics
-        ])
+        )
 
 
 class LadderBot(OneBaseTurtle):

--- a/dummies/terran/terran_random.py
+++ b/dummies/terran/terran_random.py
@@ -1,6 +1,6 @@
 import random
 
-val = random.randint(0, 6)
+val = random.randint(0, 7)
 
 if val == 0:
     from .battle_cruisers import LadderBot
@@ -16,6 +16,8 @@ elif val == 5:
     from .two_base_tanks import LadderBot
 elif val == 6:
     from .bio import LadderBot
+elif val == 7:
+    from .one_base_turtle import LadderBot
 
 class RandomTerranBot(LadderBot):
     pass

--- a/dummies/terran/two_base_tanks.py
+++ b/dummies/terran/two_base_tanks.py
@@ -94,10 +94,10 @@ class TwoBaseTanks(KnowledgeBot):
             self.attack,
             PlanFinishEnemy(),
         ]
-        return BuildOrder([
+        return BuildOrder(
             build_order,
             tactics
-        ])
+        )
 
     def should_expand(self, knowledge):
         count = 0

--- a/dummies/zerg/macro_roach.py
+++ b/dummies/zerg/macro_roach.py
@@ -74,7 +74,7 @@ class MacroRoach(KnowledgeBot):
             Step(RequiredUnitReady(UnitTypeId.ROACH, 10), MorphRavager(50), skip_until=RequiredGas(300))
         ]
 
-        build = BuildOrder([
+        build = BuildOrder(
             ZergUnit(UnitTypeId.DRONE, 70),
             AutoOverLord(),
             build_steps_exps,
@@ -85,7 +85,7 @@ class MacroRoach(KnowledgeBot):
             bsus,
             ravagers,
             build_steps_units,
-        ])
+        )
 
         attack = PlanZoneAttack(120)
 
@@ -100,10 +100,10 @@ class MacroRoach(KnowledgeBot):
             PlanFinishEnemy(),
         ]
 
-        return BuildOrder([
+        return BuildOrder(
             build,
             tactics
-        ])
+        )
 
 
 class LadderBot(MacroRoach):

--- a/dummies/zerg/macro_zerg_v2.py
+++ b/dummies/zerg/macro_zerg_v2.py
@@ -59,14 +59,14 @@ class MacroBuild(BuildOrder):
             Step(None, ActTech(UpgradeId.ANABOLICSYNTHESIS)),
         ]
 
-        super().__init__([
+        super().__init__(
             self.overlords,
             ultras,
             units,
             build_step_expansions,
             queens,
             pool_and_tech
-        ])
+        )
 
 
 class MacroZergV2(KnowledgeBot):
@@ -84,10 +84,10 @@ class MacroZergV2(KnowledgeBot):
             attack,
             PlanFinishEnemy(),
         ]
-        return BuildOrder([
+        return BuildOrder(
             MacroBuild(),
             tactics,
-        ])
+        )
 
 
 class LadderBot(MacroZergV2):

--- a/dummies/zerg/mutalisk.py
+++ b/dummies/zerg/mutalisk.py
@@ -105,9 +105,9 @@ class MutaliskBot(KnowledgeBot):
             lambda k: len(self.enemy_start_locations) == 1), skip_until=RequiredSupply(20))
         distribute = PlanDistributeWorkers()
 
-        return BuildOrder([
+        return BuildOrder(
             MutaliskBuild(),
-            SequentialList([
+            SequentialList(
                 PlanCancelBuilding(),
                 PlanZoneGather(),
                 PlanZoneDefense(),
@@ -117,8 +117,8 @@ class MutaliskBot(KnowledgeBot):
                 distribute,
                 PlanZoneAttack(),
                 PlanFinishEnemy()
-            ]),
-        ])
+            ),
+        )
 
 
 class LadderBot(MutaliskBot):

--- a/dummies/zerg/roach_hydra.py
+++ b/dummies/zerg/roach_hydra.py
@@ -94,9 +94,9 @@ class RoachHydra(KnowledgeBot):
             lambda k: len(self.enemy_start_locations) == 1), skip_until=RequiredSupply(20))
         self.distribute = PlanDistributeWorkers()
 
-        return BuildOrder([
+        return BuildOrder(
             RoachHydraBuild(),
-            SequentialList([
+            SequentialList(
                 PlanCancelBuilding(),
                 PlanZoneGather(),
                 PlanZoneDefense(),
@@ -106,8 +106,8 @@ class RoachHydra(KnowledgeBot):
                 self.distribute,
                 PlanZoneAttack(),
                 PlanFinishEnemy()
-            ]),
-        ])
+            ),
+        )
 
 
 class LadderBot(RoachHydra):

--- a/dummies/zerg/twelve_pool.py
+++ b/dummies/zerg/twelve_pool.py
@@ -65,7 +65,7 @@ class TwelvePool(KnowledgeBot):
 
         ]
 
-        return BuildOrder([
+        return BuildOrder(
             build_step_buildings,
             finish,
             build_step_units,
@@ -76,7 +76,7 @@ class TwelvePool(KnowledgeBot):
             PlanZoneGather(),
             PlanZoneAttack2(2),
             PlanFinishEnemy(),
-        ])
+        )
 
 
 class LadderBot(TwelvePool):

--- a/dummies/zerg/worker_rush.py
+++ b/dummies/zerg/worker_rush.py
@@ -221,18 +221,18 @@ class WorkerRush(KnowledgeBot):
         stop_gas = RequiredAny([RequiredGas(100), RequiredTechReady(UpgradeId.ZERGLINGMOVEMENTSPEED, 0.001)])
         end_game = RequiredAny([RequiredSupply(70), RequiredUnitExists(UnitTypeId.LAIR, 1)])
 
-        return BuildOrder([
+        return BuildOrder(
             ActUnitOnce(UnitTypeId.DRONE, UnitTypeId.LARVA, 24),
             LingFloodBuild(),
-            SequentialList([
+            SequentialList(
                 InjectLarva(),
                 Step(None, PlanDistributeWorkers(3, 3), skip=RequiredAny([stop_gas, end_game])),
                 Step(None, PlanDistributeWorkers(0, 0), skip_until=stop_gas, skip=end_game),
                 Step(None, PlanDistributeWorkers(None, None), skip_until=end_game),
                 WorkerAttack(),
                 DummyZergAttack()
-            ]),
-        ])
+            ),
+        )
 
 
 class LadderBot(WorkerRush):

--- a/sharpy/plans/build_step.py
+++ b/sharpy/plans/build_step.py
@@ -1,14 +1,18 @@
 from typing import Optional, Callable, Union
 
 # Singular step of action
+from sharpy.plans.acts import ActCustom
 from sharpy.plans.require import RequireCustom
 from sharpy.plans.require.require_base import RequireBase
 from sharpy.plans.acts.act_base import ActBase
+from typing import TYPE_CHECKING
+if TYPE_CHECKING:
+    from sharpy.knowledges import Knowledge
 
 class Step(ActBase):
     def __init__(self,
                  requirement: Optional[Union[RequireBase, Callable[['Knowledge'], bool]]],
-                 action: Optional[ActBase],
+                 action: Optional[Union[ActBase, Callable[['Knowledge'], bool]]],
                  skip: Optional[Union[RequireBase, Callable[['Knowledge'], bool]]] = None,
                  skip_until: Optional[Union[RequireBase, Callable[['Knowledge'], bool]]] = None):
         assert requirement is None or isinstance(requirement, RequireBase) or isinstance(requirement, Callable)
@@ -17,18 +21,24 @@ class Step(ActBase):
         assert skip_until is None or isinstance(skip_until, RequireBase) or isinstance(skip_until, Callable)
         super().__init__()
 
-        self.requirement = requirement
-        self.action = action
-        self.skip = skip
-        self.skip_until = skip_until
+        self.requirement = Step.merge_to_require(requirement)
+        self.action = Step.merge_to_act(action)
+        self.skip = Step.merge_to_require(skip)
+        self.skip_until = Step.merge_to_require(skip_until)
 
-        if isinstance(self.requirement, Callable):
-            self.requirement = RequireCustom(self.requirement)
-        if isinstance(self.skip, Callable):
-            self.skip = RequireCustom(self.skip)
+    @staticmethod
+    def merge_to_act(obj: Optional[Union[ActBase, Callable[['Knowledge'], bool]]]) -> Optional[ActBase]:
+        if isinstance(obj, ActBase) or obj is None:
+            return obj
+        assert isinstance(obj, Callable)
+        return ActCustom(obj)
 
-        if isinstance(self.skip_until, Callable):
-            self.skip_until = RequireCustom(self.skip_until)
+    @staticmethod
+    def merge_to_require(obj: Optional[Union[RequireBase, Callable[['Knowledge'], bool]]]) -> Optional[RequireBase]:
+        if isinstance(obj, RequireBase) or obj is None:
+            return obj
+        assert isinstance(obj, Callable)
+        return RequireCustom(obj)
 
     async def debug_draw(self):
         if self.requirement is not None:

--- a/sharpy/plans/sequential_list.py
+++ b/sharpy/plans/sequential_list.py
@@ -1,16 +1,33 @@
-from typing import List
+from typing import List, Union, Callable
 
+from sharpy.plans.build_step import Step
 from sharpy.plans.acts import ActBase
 
+from typing import TYPE_CHECKING
+if TYPE_CHECKING:
+    from sharpy.knowledges import Knowledge
 
 class SequentialList(ActBase):
-    def __init__(self, orders: List[ActBase]):
-        assert orders is not None and isinstance(orders, list)
-        super().__init__()
-        for order in orders:
-            assert isinstance(order, ActBase)
+    def __init__(self,
+                 orders: Union[Union[ActBase, Callable[['Knowledge'], bool]],
+                               List[Union[ActBase, Callable[['Knowledge'], bool]]]],
+                 *argv):
 
-        self.orders: List[ActBase] = orders
+        is_act = isinstance(orders, ActBase) or isinstance(orders, Callable)
+        assert orders is not None and (isinstance(orders, list) or is_act)
+        super().__init__()
+
+        if is_act:
+            self.orders: List[ActBase] = [Step.merge_to_act(orders)]
+        else:
+            self.orders: List[ActBase] = []
+            for order in orders:
+                assert order is not None
+                self.orders.append(Step.merge_to_act(order))
+
+        for order in argv:
+            assert order is not None
+            self.orders.append(Step.merge_to_act(order))
 
     async def debug_draw(self):
         for order in self.orders:


### PR DESCRIPTION
Used *argv parameter in `BuildOrder` and `SequentialList` in order to allow creation of builds without hacing to add additional []. Also unified Step / SequentialList / BuildOrder to also accept lambdas / methods as replacement acts.

Removed most if not all extra [] definitions from dummy bots.