### PR TITLE
POC of how we can change and deprecate class names

### DIFF
--- a/dummies/protoss/adept_allin.py
+++ b/dummies/protoss/adept_allin.py
@@ -36,8 +36,8 @@ class AdeptRush(KnowledgeBot):
             Step(
                 None,
                 ChronoUnitProduction(UnitTypeId.PROBE, UnitTypeId.NEXUS),
-                skip=RequiredUnitExists(UnitTypeId.PROBE, 20, include_pending=True),
-                skip_until=RequiredUnitExists(UnitTypeId.ASSIMILATOR, 1),
+                skip=UnitExists(UnitTypeId.PROBE, 20, include_pending=True),
+                skip_until=UnitExists(UnitTypeId.ASSIMILATOR, 1),
             ),
             SequentialList(
                 GridBuilding(UnitTypeId.PYLON, 1),
@@ -65,7 +65,7 @@ class AdeptRush(KnowledgeBot):
                         GateUnit(UnitTypeId.ADEPT, 100),
                     ),
                     Step(
-                        RequiredUnitExists(UnitTypeId.CYBERNETICSCORE, 1),
+                        UnitExists(UnitTypeId.CYBERNETICSCORE, 1),
                         GridBuilding(UnitTypeId.GATEWAY, 4),
                         skip_until=RequiredMinerals(200),
                     ),

--- a/sharpy/plans/require/__init__.py
+++ b/sharpy/plans/require/__init__.py
@@ -9,8 +9,8 @@ from .required_supply_left import RequiredSupplyLeft
 from .required_tech_ready import RequiredTechReady
 from .required_time import RequiredTime
 from .required_total_unit_exists import RequiredTotalUnitExists
-from .required_enemy_unit_exists import RequiredEnemyUnitExists
 from .unit_exists import UnitExists, RequiredUnitExists
+from .enemy_unit_exists import EnemyUnitExists, RequiredEnemyUnitExists
 from .required_less_unit_exists import RequiredLessUnitExists
 from .required_unit_ready import RequiredUnitReady
 from .required_enemy_unit_exists_after import RequiredEnemyUnitExistsAfter

--- a/sharpy/plans/require/__init__.py
+++ b/sharpy/plans/require/__init__.py
@@ -9,8 +9,8 @@ from .required_supply_left import RequiredSupplyLeft
 from .required_tech_ready import RequiredTechReady
 from .required_time import RequiredTime
 from .required_total_unit_exists import RequiredTotalUnitExists
-from .required_unit_exists import RequiredUnitExists
 from .required_enemy_unit_exists import RequiredEnemyUnitExists
+from .unit_exists import UnitExists, RequiredUnitExists
 from .required_less_unit_exists import RequiredLessUnitExists
 from .required_unit_ready import RequiredUnitReady
 from .required_enemy_unit_exists_after import RequiredEnemyUnitExistsAfter

--- a/sharpy/plans/require/enemy_unit_exists.py
+++ b/sharpy/plans/require/enemy_unit_exists.py
@@ -1,9 +1,11 @@
+import warnings
+
 from sc2 import UnitTypeId
 
 from sharpy.plans.require.require_base import RequireBase
 
 
-class RequiredEnemyUnitExists(RequireBase):
+class EnemyUnitExists(RequireBase):
     """
     Checks if enemy has units of the type based on the information we have seen.
     """
@@ -25,3 +27,9 @@ class RequiredEnemyUnitExists(RequireBase):
             return True
 
         return False
+
+
+class RequiredEnemyUnitExists(EnemyUnitExists):
+    def __init__(self, unit_type: UnitTypeId, count: int = 1):
+        warnings.warn("'RequiredEnemyUnitExists' is deprecated, use 'EnemyUnitExists' instead", DeprecationWarning, 2)
+        super().__init__(unit_type, count)

--- a/sharpy/plans/require/unit_exists.py
+++ b/sharpy/plans/require/unit_exists.py
@@ -1,10 +1,12 @@
+import warnings
+
 import sc2
 from sc2 import UnitTypeId
 
 from sharpy.plans.require.require_base import RequireBase
 
 
-class RequiredUnitExists(RequireBase):
+class UnitExists(RequireBase):
     def __init__(
         self,
         unit_type: UnitTypeId,
@@ -30,3 +32,16 @@ class RequiredUnitExists(RequireBase):
     def check(self) -> bool:
         count = self.get_count(self.unit_type, self.include_pending, self.include_killed, self.include_not_ready)
         return count >= self.count
+
+
+class RequiredUnitExists(UnitExists):
+    def __init__(
+        self,
+        unit_type: UnitTypeId,
+        count: int = 1,
+        include_pending: bool = False,
+        include_killed: bool = False,
+        include_not_ready: bool = True,
+    ):
+        warnings.warn("'RequiredUnitExists' is deprecated, use 'UnitExists' instead", DeprecationWarning, 2)
+        super().__init__(unit_type, count, include_pending, include_killed, include_not_ready)


### PR DESCRIPTION
This is how we can change class names without breaking any old bots.

A deprecated class looks like this in PyCharm:
![kuva](https://user-images.githubusercontent.com/1806447/79068546-6c493400-7cd0-11ea-8b92-ac69c47a0f88.png)

And results in warnings like this in console:
```
C:\Dev\sc2\sharpy-sc2\dummies\terran\bio.py:201: DeprecationWarning: 'RequiredUnitExists' is deprecated, use 'UnitExists' instead
  worker_scout = Step(None, WorkerScout(), skip_until=RequiredUnitExists(UnitTypeId.SUPPLYDEPOT, 1))
C:\Dev\sc2\sharpy-sc2\sharpy\plans\build_order.py:68: DeprecationWarning: 'RequiredEnemyUnitExists' is deprecated, use 'EnemyUnitExists' instead
  require_list.append(RequiredEnemyUnitExists(unit_type, count))
```

To test this PR, these dummies are a good option since they use both of the renamed classes:

```
 py run_custom.py -p1 adept -p2 bio
```