### PR TITLE
Generic scouting

### DIFF
--- a/dummies/zerg/lurkers.py
+++ b/dummies/zerg/lurkers.py
@@ -221,8 +221,8 @@ class LurkerBot(KnowledgeBot):
             SequentialList(
                 PlanZoneDefense(),
                 OverlordScout(),
-                Step(None, LingScoutMain(), skip_until=RequiredTime(4 * 60)),
-                Step(None, LingScoutMain(), skip_until=RequiredTime(8 * 60)),
+                Step(None, LingScout(), skip_until=RequiredTime(4 * 60)),
+                Step(None, LingScout(), skip_until=RequiredTime(8 * 60)),
                 PlanCancelBuilding(),
                 PlanZoneGather(),
                 Step(None, WorkerScout(), skip_until=RequiredSupply(20)),

--- a/sharpy/knowledges/knowledge.py
+++ b/sharpy/knowledges/knowledge.py
@@ -311,16 +311,6 @@ class Knowledge:
             return False
         return not unit.is_structure and self.my_worker_type != unit.type_id
 
-    def building_going_down(self, building: Unit) -> bool:
-        """Returns boolean indicating whether a building is low on health and under attack."""
-        if building.tag in self.previous_units_manager.previous_units:
-            previous_building = self.previous_units_manager.previous_units[building.tag]
-            health = building.health
-            compare_health = max(70, building.health_max * 0.09)
-            if health < previous_building.health < compare_health:
-                return True
-        return False
-
     @property
     def enemy_expansions_dict(self) -> Dict[Point2, Unit]:
         """Dictionary of known expansion locations that have an enemy townhall present."""

--- a/sharpy/knowledges/knowledge.py
+++ b/sharpy/knowledges/knowledge.py
@@ -547,6 +547,11 @@ class Knowledge:
         """Gets correct z from versions 4.9.0+"""
         return -16 + 32 * h / 255
 
+    def z_height_to_terrain(self, z):
+        """Gets correct height from versions 4.9.0+"""
+        h = (z + 16) / 32 * 255
+        return h
+
     async def post_update(self):
         for manager in self.managers:
             await manager.post_update()

--- a/sharpy/managers/manager_base.py
+++ b/sharpy/managers/manager_base.py
@@ -6,17 +6,21 @@ from sc2 import Result, UnitTypeId
 
 import sc2
 from sc2.client import Client
+from typing import TYPE_CHECKING
 
+if TYPE_CHECKING:
+    from sharpy.knowledges import Knowledge
+    from sharpy.managers import UnitCacheManager, UnitValue
 
 class ManagerBase(ABC):
-    def __init__(self):
-        self.knowledge: "Knowledge" = None
-        self.ai: sc2.BotAI = None
-        self.unit_values: "UnitValue" = None
-        self._debug: bool = False
+    ai: sc2.BotAI
+    knowledge: "Knowledge"
+    unit_values: "UnitValue"
+    cache: "UnitCacheManager"
+    client: Client
 
-        self.client: Client = None
-        self.cache: "UnitCacheManager" = None
+    def __init__(self):
+        self._debug: bool = False
 
     @property
     def debug(self):

--- a/sharpy/managers/manager_base.py
+++ b/sharpy/managers/manager_base.py
@@ -12,6 +12,7 @@ if TYPE_CHECKING:
     from sharpy.knowledges import Knowledge
     from sharpy.managers import UnitCacheManager, UnitValue
 
+
 class ManagerBase(ABC):
     ai: sc2.BotAI
     knowledge: "Knowledge"

--- a/sharpy/managers/roles/unit_task.py
+++ b/sharpy/managers/roles/unit_task.py
@@ -1,7 +1,7 @@
 import enum
 
 
-class UnitTask(enum.Enum):
+class UnitTask(enum.IntEnum):
     # Do NOT change order or the number values!
     Idle = 0
     Building = 1  # Worker only
@@ -12,4 +12,4 @@ class UnitTask(enum.Enum):
     Defending = 6  # Defending a zone
     Attacking = 7  # Attacking enemy base
     Reserved = 8  # Reserved for some unknown purpose, i.e. gate keeper
-    Hallucination = 9  # Not a real unit.
+    Hallucination = 9  # Not a real unit. Either a hallucination or changeling

--- a/sharpy/managers/unit_cache_manager.py
+++ b/sharpy/managers/unit_cache_manager.py
@@ -12,25 +12,31 @@ from sc2.units import Units
 from sharpy.managers.manager_base import ManagerBase
 from sc2 import UnitTypeId
 from sc2.unit import Unit
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from sharpy.knowledges import Knowledge
 
 
 class UnitCacheManager(ManagerBase):
     """Provides performance optimized methods for filtering both own and enemy units based on unit type and position."""
+    all_own: Units
+    empty_units: Units
 
     def __init__(self):
         super().__init__()
         self.tag_cache: Dict[int, Unit] = {}
         self.own_unit_cache: Dict[UnitTypeId, Units] = {}
         self.enemy_unit_cache: Dict[UnitTypeId, Units] = {}
-        self.empty_units: Units = None
         self.own_tree: Optional[cKDTree] = None
         self.enemy_tree: Optional[cKDTree] = None
         self.force_fields: List[EffectData] = []
-        self.all_own: Units = Units([], self.ai)
+
         self.mineral_fields: Dict[Point2, Unit] = {}
 
     async def start(self, knowledge: "Knowledge"):
         await super().start(knowledge)
+        self.all_own: Units = Units([], self.ai)
         self.empty_units: Units = Units([], self.ai)
 
     def by_tag(self, tag: int) -> Optional[Unit]:

--- a/sharpy/managers/unit_cache_manager.py
+++ b/sharpy/managers/unit_cache_manager.py
@@ -20,6 +20,7 @@ if TYPE_CHECKING:
 
 class UnitCacheManager(ManagerBase):
     """Provides performance optimized methods for filtering both own and enemy units based on unit type and position."""
+
     all_own: Units
     empty_units: Units
 

--- a/sharpy/managers/unit_role_manager.py
+++ b/sharpy/managers/unit_role_manager.py
@@ -97,11 +97,24 @@ class UnitRoleManager(ManagerBase):
     @property
     def attacking_units(self) -> Units:
         """Returns all units that are currently attacking."""
-        attacking_units = self.roles[UnitTask.Attacking.value].units.copy()
+        attacking_units = Units(self.roles[UnitTask.Attacking.value].units.copy(), self.ai)
         moving_units = self.roles[UnitTask.Moving.value].units.copy()
         # Combine lists
         attacking_units.extend(moving_units)
         return attacking_units
+
+    def get_types_from(self, types: Set[UnitTypeId], *args: UnitTask) -> Units:
+        units = self.cache.own(types)
+        all_tags: List[int] = []
+
+        if len(args) == 0:
+            all_tags = self.roles[UnitTask.Idle].tags
+        else:
+            for task in args:
+                tags = self.roles[task].tags
+                all_tags += tags
+
+        return units.tags_in(all_tags)
 
     @property
     def hallucinated_units(self) -> Units:

--- a/sharpy/plans/__init__.py
+++ b/sharpy/plans/__init__.py
@@ -2,3 +2,4 @@ from .build_order import BuildOrder
 from .build_order import Step
 from .step_gas import StepBuildGas
 from .sequential_list import SequentialList
+from .sub_acts import SubActs

--- a/sharpy/plans/acts/__init__.py
+++ b/sharpy/plans/acts/__init__.py
@@ -18,3 +18,4 @@ from .defensive_building import DefensePosition
 from .reserve import Reserve
 from .act_custom import ActCustom
 from .position_building import PositionBuilding
+from .methods import merge_to_act

--- a/sharpy/plans/acts/methods.py
+++ b/sharpy/plans/acts/methods.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from sharpy.knowledges import Knowledge
 
+
 def merge_to_act(obj: Optional[Union[ActBase, Callable[["Knowledge"], bool]]]) -> Optional[ActBase]:
     if isinstance(obj, ActBase) or obj is None:
         return obj

--- a/sharpy/plans/acts/methods.py
+++ b/sharpy/plans/acts/methods.py
@@ -1,0 +1,23 @@
+from typing import Optional, Union, Callable
+
+from sharpy.plans.acts.act_base import ActBase
+from sharpy.plans.acts.act_custom import ActCustom
+from sharpy.plans.require.require_custom import RequireCustom
+from sharpy.plans.require.require_base import RequireBase
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from sharpy.knowledges import Knowledge
+
+def merge_to_act(obj: Optional[Union[ActBase, Callable[["Knowledge"], bool]]]) -> Optional[ActBase]:
+    if isinstance(obj, ActBase) or obj is None:
+        return obj
+    assert isinstance(obj, Callable)
+    return ActCustom(obj)
+
+
+def merge_to_require(obj: Optional[Union[RequireBase, Callable[["Knowledge"], bool]]]) -> Optional[RequireBase]:
+    if isinstance(obj, RequireBase) or obj is None:
+        return obj
+    assert isinstance(obj, Callable)
+    return RequireCustom(obj)

--- a/sharpy/plans/build_order.py
+++ b/sharpy/plans/build_order.py
@@ -4,7 +4,7 @@ import sc2
 from sc2 import UnitTypeId
 from sc2.ids.upgrade_id import UpgradeId
 
-from sharpy.plans.acts import ActTech, ActUnit, ActBase
+from sharpy.plans.acts import ActTech, ActUnit, ActBase, merge_to_act
 from sharpy.plans.acts.grid_building import GridBuilding
 from sharpy.plans.build_step import Step
 from sharpy.plans.require import (
@@ -52,7 +52,7 @@ class BuildOrder(ActBase):
             if isinstance(order, list):
                 self.orders.append(SequentialList(order))
             else:
-                self.orders.append(Step.merge_to_act(order))
+                self.orders.append(merge_to_act(order))
 
     async def debug_draw(self):
         for order in self.orders:

--- a/sharpy/plans/build_step.py
+++ b/sharpy/plans/build_step.py
@@ -1,8 +1,8 @@
 from typing import Optional, Callable, Union
 
 # Singular step of action
-from sharpy.plans.acts import ActCustom
-from sharpy.plans.require import RequireCustom
+from sharpy.plans.acts import merge_to_act
+from sharpy.plans.require import merge_to_require
 from sharpy.plans.require.require_base import RequireBase
 from sharpy.plans.acts.act_base import ActBase
 from typing import TYPE_CHECKING
@@ -25,24 +25,10 @@ class Step(ActBase):
         assert skip_until is None or isinstance(skip_until, RequireBase) or isinstance(skip_until, Callable)
         super().__init__()
 
-        self.requirement = Step.merge_to_require(requirement)
-        self.action = Step.merge_to_act(action)
-        self.skip = Step.merge_to_require(skip)
-        self.skip_until = Step.merge_to_require(skip_until)
-
-    @staticmethod
-    def merge_to_act(obj: Optional[Union[ActBase, Callable[["Knowledge"], bool]]]) -> Optional[ActBase]:
-        if isinstance(obj, ActBase) or obj is None:
-            return obj
-        assert isinstance(obj, Callable)
-        return ActCustom(obj)
-
-    @staticmethod
-    def merge_to_require(obj: Optional[Union[RequireBase, Callable[["Knowledge"], bool]]]) -> Optional[RequireBase]:
-        if isinstance(obj, RequireBase) or obj is None:
-            return obj
-        assert isinstance(obj, Callable)
-        return RequireCustom(obj)
+        self.requirement = merge_to_require(requirement)
+        self.action = merge_to_act(action)
+        self.skip = merge_to_require(skip)
+        self.skip_until = merge_to_require(skip_until)
 
     async def debug_draw(self):
         if self.requirement is not None:

--- a/sharpy/plans/require/__init__.py
+++ b/sharpy/plans/require/__init__.py
@@ -17,3 +17,4 @@ from .required_enemy_unit_exists_after import RequiredEnemyUnitExistsAfter
 from .required_enemy_building_exists import RequiredEnemyBuildingExists
 from .required_count import RequiredCount
 from .required_supply import SupplyType
+from .methods import merge_to_require

--- a/sharpy/plans/require/methods.py
+++ b/sharpy/plans/require/methods.py
@@ -7,7 +7,6 @@ if TYPE_CHECKING:
     from sharpy.knowledges import Knowledge
 
 
-
 def merge_to_require(obj: Optional[Union[RequireBase, Callable[["Knowledge"], bool]]]) -> Optional[RequireBase]:
     if isinstance(obj, RequireBase) or obj is None:
         return obj

--- a/sharpy/plans/require/methods.py
+++ b/sharpy/plans/require/methods.py
@@ -1,0 +1,15 @@
+from typing import Optional, Union, Callable
+from sharpy.plans.require.require_custom import RequireCustom
+from sharpy.plans.require.require_base import RequireBase
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from sharpy.knowledges import Knowledge
+
+
+
+def merge_to_require(obj: Optional[Union[RequireBase, Callable[["Knowledge"], bool]]]) -> Optional[RequireBase]:
+    if isinstance(obj, RequireBase) or obj is None:
+        return obj
+    assert isinstance(obj, Callable)
+    return RequireCustom(obj)

--- a/sharpy/plans/require/required_all.py
+++ b/sharpy/plans/require/required_all.py
@@ -1,6 +1,5 @@
 from typing import List, Callable, Union
-
-from sharpy.plans import Step
+from sharpy.plans.require.methods import merge_to_require
 from sharpy.plans.require import RequireBase
 from typing import TYPE_CHECKING
 
@@ -23,19 +22,16 @@ class RequiredAll(RequireBase):
         super().__init__()
 
         if is_act:
-            self.conditions: List[RequireBase] = [Step.merge_to_require(conditions)]
+            self.conditions: List[RequireBase] = [merge_to_require(conditions)]
         else:
             self.conditions: List[RequireBase] = []
             for order in conditions:
                 assert order is not None
-                self.conditions.append(Step.merge_to_require(order))
+                self.conditions.append(merge_to_require(order))
 
         for order in args:
             assert order is not None
-            self.conditions.append(Step.merge_to_require(order))
-
-        assert conditions is not None and isinstance(conditions, List)
-        self.conditions: List[RequireBase] = conditions
+            self.conditions.append(merge_to_require(order))
 
     async def start(self, knowledge: "Knowledge"):
         await super().start(knowledge)

--- a/sharpy/plans/require/required_all.py
+++ b/sharpy/plans/require/required_all.py
@@ -1,15 +1,39 @@
-from typing import List
+from typing import List, Callable, Union
 
-from sc2 import BotAI
-
+from sharpy.plans import Step
 from sharpy.plans.require import RequireBase
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from sharpy.knowledges import Knowledge
 
 
 class RequiredAll(RequireBase):
     """Check passes if all of the conditions are true."""
 
-    def __init__(self, conditions: List[RequireBase]):
+    def __init__(
+        self,
+        conditions: Union[RequireBase, Callable[["Knowledge"], bool], List[RequireBase]],
+        *args: Union[RequireBase, Callable[["Knowledge"], bool]]
+    ):
         super().__init__()
+
+        is_act = isinstance(conditions, RequireBase) or isinstance(conditions, Callable)
+        assert conditions is not None and (isinstance(conditions, list) or is_act)
+        super().__init__()
+
+        if is_act:
+            self.conditions: List[RequireBase] = [Step.merge_to_require(conditions)]
+        else:
+            self.conditions: List[RequireBase] = []
+            for order in conditions:
+                assert order is not None
+                self.conditions.append(Step.merge_to_require(order))
+
+        for order in args:
+            assert order is not None
+            self.conditions.append(Step.merge_to_require(order))
+
         assert conditions is not None and isinstance(conditions, List)
         self.conditions: List[RequireBase] = conditions
 

--- a/sharpy/plans/require/required_any.py
+++ b/sharpy/plans/require/required_any.py
@@ -1,6 +1,6 @@
 from typing import List, Callable, Union
 
-from sharpy.plans import Step
+from sharpy.plans.require.methods import merge_to_require
 from sharpy.plans.require import RequireBase
 from typing import TYPE_CHECKING
 
@@ -23,19 +23,16 @@ class RequiredAny(RequireBase):
         super().__init__()
 
         if is_act:
-            self.conditions: List[RequireBase] = [Step.merge_to_require(conditions)]
+            self.conditions: List[RequireBase] = [merge_to_require(conditions)]
         else:
             self.conditions: List[RequireBase] = []
             for order in conditions:
                 assert order is not None
-                self.conditions.append(Step.merge_to_require(order))
+                self.conditions.append(merge_to_require(order))
 
         for order in args:
             assert order is not None
-            self.conditions.append(Step.merge_to_require(order))
-
-        assert conditions is not None and isinstance(conditions, List)
-        self.conditions: List[RequireBase] = conditions
+            self.conditions.append(merge_to_require(order))
 
     async def start(self, knowledge: "Knowledge"):
         await super().start(knowledge)

--- a/sharpy/plans/sequential_list.py
+++ b/sharpy/plans/sequential_list.py
@@ -12,9 +12,13 @@ if TYPE_CHECKING:
 
 
 class SequentialList(SubActs):
-    def __init__(self, orders: Union[
-        Union[ActBase, Callable[["Knowledge"], bool]], List[Union[ActBase, Callable[["Knowledge"], bool]]]
-    ], *argv):
+    def __init__(
+        self,
+        orders: Union[
+            Union[ActBase, Callable[["Knowledge"], bool]], List[Union[ActBase, Callable[["Knowledge"], bool]]]
+        ],
+        *argv
+    ):
 
         super().__init__(orders, *argv)
 

--- a/sharpy/plans/sequential_list.py
+++ b/sharpy/plans/sequential_list.py
@@ -5,43 +5,18 @@ from sharpy.plans.acts import ActBase
 
 from typing import TYPE_CHECKING
 
+from sharpy.plans.sub_acts import SubActs
+
 if TYPE_CHECKING:
     from sharpy.knowledges import Knowledge
 
 
-class SequentialList(ActBase):
-    def __init__(
-        self,
-        orders: Union[
-            Union[ActBase, Callable[["Knowledge"], bool]], List[Union[ActBase, Callable[["Knowledge"], bool]]]
-        ],
-        *argv,
-    ):
+class SequentialList(SubActs):
+    def __init__(self, orders: Union[
+        Union[ActBase, Callable[["Knowledge"], bool]], List[Union[ActBase, Callable[["Knowledge"], bool]]]
+    ], *argv):
 
-        is_act = isinstance(orders, ActBase) or isinstance(orders, Callable)
-        assert orders is not None and (isinstance(orders, list) or is_act)
-        super().__init__()
-
-        if is_act:
-            self.orders: List[ActBase] = [Step.merge_to_act(orders)]
-        else:
-            self.orders: List[ActBase] = []
-            for order in orders:
-                assert order is not None
-                self.orders.append(Step.merge_to_act(order))
-
-        for order in argv:
-            assert order is not None
-            self.orders.append(Step.merge_to_act(order))
-
-    async def debug_draw(self):
-        for order in self.orders:
-            await order.debug_draw()
-
-    async def start(self, knowledge: "Knowledge"):
-        await super().start(knowledge)
-        for order in self.orders:
-            await order.start(knowledge)
+        super().__init__(orders, *argv)
 
     async def execute(self) -> bool:
         for order in self.orders:

--- a/sharpy/plans/sub_acts.py
+++ b/sharpy/plans/sub_acts.py
@@ -1,0 +1,44 @@
+from typing import List, Union, Callable
+
+from sharpy.plans.build_step import Step
+from sharpy.plans.acts import ActBase
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from sharpy.knowledges import Knowledge
+
+
+class SubActs(ActBase):
+    def __init__(
+        self,
+        orders: Union[
+            Union[ActBase, Callable[["Knowledge"], bool]], List[Union[ActBase, Callable[["Knowledge"], bool]]]
+        ],
+        *argv: Union[ActBase, Callable[["Knowledge"], bool]],
+    ):
+
+        is_act = isinstance(orders, ActBase) or isinstance(orders, Callable)
+        assert orders is not None and (isinstance(orders, list) or is_act)
+        super().__init__()
+
+        if is_act:
+            self.orders: List[ActBase] = [Step.merge_to_act(orders)]
+        else:
+            self.orders: List[ActBase] = []
+            for order in orders:
+                assert order is not None
+                self.orders.append(Step.merge_to_act(order))
+
+        for order in argv:
+            assert order is not None
+            self.orders.append(Step.merge_to_act(order))
+
+    async def debug_draw(self):
+        for order in self.orders:
+            await order.debug_draw()
+
+    async def start(self, knowledge: "Knowledge"):
+        await super().start(knowledge)
+        for order in self.orders:
+            await order.start(knowledge)

--- a/sharpy/plans/sub_acts.py
+++ b/sharpy/plans/sub_acts.py
@@ -5,6 +5,8 @@ from sharpy.plans.acts import ActBase
 
 from typing import TYPE_CHECKING
 
+from sharpy.plans.acts import merge_to_act
+
 if TYPE_CHECKING:
     from sharpy.knowledges import Knowledge
 
@@ -23,16 +25,16 @@ class SubActs(ActBase):
         super().__init__()
 
         if is_act:
-            self.orders: List[ActBase] = [Step.merge_to_act(orders)]
+            self.orders: List[ActBase] = [merge_to_act(orders)]
         else:
             self.orders: List[ActBase] = []
             for order in orders:
                 assert order is not None
-                self.orders.append(Step.merge_to_act(order))
+                self.orders.append(merge_to_act(order))
 
         for order in argv:
             assert order is not None
-            self.orders.append(Step.merge_to_act(order))
+            self.orders.append(merge_to_act(order))
 
     async def debug_draw(self):
         for order in self.orders:

--- a/sharpy/plans/tactics/__init__.py
+++ b/sharpy/plans/tactics/__init__.py
@@ -10,3 +10,4 @@ from .worker_scout import WorkerScout
 from .warn_build_macro import WarnBuildMacro
 from .worker_counterattack import WorkerCounterAttack
 from .worker_rally_point import WorkerRallyPoint
+from .scout import Scout, ScoutLocation

--- a/sharpy/plans/tactics/cancel_building.py
+++ b/sharpy/plans/tactics/cancel_building.py
@@ -12,9 +12,19 @@ class PlanCancelBuilding(ActBase):
     async def execute(self) -> bool:
         for building in self.ai.structures:  # type: Unit
             if 1 > building.build_progress > 0:
-                if self.knowledge.building_going_down(building):
+                if self.building_going_down(building):
                     self.print(
                         f"Cancelled {building.type_id.name} at {building.position} with {building.health} health"
                     )
                     self.do(building(AbilityId.CANCEL_BUILDINPROGRESS))
         return True
+
+    def building_going_down(self, building: Unit) -> bool:
+        """Returns boolean indicating whether a building is low on health and under attack."""
+        if building.tag in self.knowledge.previous_units_manager.previous_units:
+            previous_building = self.knowledge.previous_units_manager.previous_units[building.tag]
+            health = building.health
+            compare_health = max(70, building.health_max * 0.09)
+            if health < previous_building.health < compare_health:
+                return True
+        return False

--- a/sharpy/plans/tactics/scout.py
+++ b/sharpy/plans/tactics/scout.py
@@ -1,0 +1,125 @@
+from typing import List, Callable, Set, Union
+
+from sc2 import UnitTypeId
+from sc2.position import Point2
+from sc2.unit import Unit
+from sc2.units import Units
+from sharpy.managers.roles import UnitTask
+from sharpy.plans import SubActs
+from sharpy.plans.acts import ActBase
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from sharpy.knowledges import Knowledge
+
+
+class ScoutBaseAction(ActBase):
+    _units: Units
+
+    def __init__(self, only_once: bool) -> None:
+        super().__init__()
+        self.current_target = Point2((0, 0))
+        self.reached = False
+        self.only_once = only_once
+
+    async def start(self, knowledge: "Knowledge"):
+        await super().start(knowledge)
+        self._units = Units([], self.ai)
+
+    def set_scouts(self, scouts: List[Unit]):
+        self._units.clear()
+        self._units.extend(scouts)
+
+
+class ScoutLocation(ScoutBaseAction):
+    def __init__(
+        self, func_target: Callable[["Knowledge"], Point2], distance_to_reach: float = 5, only_once: bool = False
+    ) -> None:
+        super().__init__(only_once)
+        self.func_target = func_target
+        self.distance_to_reach = distance_to_reach
+
+    async def execute(self) -> bool:
+        if not self._units:
+            return False
+        self.current_target = self.func_target(self.knowledge)
+        return False
+
+    @staticmethod
+    def scout_main() -> ScoutBaseAction:
+        return ScoutLocation(lambda k: k.expansion_zones[-1].behind_mineral_position_center)
+
+
+class Scout(SubActs):
+    units: Units
+
+    def __init__(self, unit_types: Union[UnitTypeId, Set[UnitTypeId]], unit_count: int, *args: ScoutBaseAction):
+        """
+        Scout act for all races, loops the given scout actions
+        @param unit_types: Types of units accepted as scouts
+        @param unit_count: Units required to be used in scouting, scouting will only start after all are available
+        @param args: Scout actions, cen be to scout a certain location, or to move around in certain way
+        """
+        if isinstance(unit_types, UnitTypeId):
+            self.unit_types = set()
+            self.unit_types.add(unit_types)
+        else:
+            self.unit_types = unit_types
+        self.unit_count = unit_count
+
+        if len(args) > 0:
+            super().__init__(*args)
+        else:
+            super().__init__(ScoutLocation.scout_main())
+
+        self.scout_tags: List[int] = []
+        self.started = False
+        self.ended = False
+        self.index = 0
+
+    async def start(self, knowledge: "Knowledge"):
+        await super().start(knowledge)
+        self.units = Units([], self.ai)
+
+    async def execute(self) -> bool:
+        if self.ended:
+            return True
+
+        self.units.clear()
+
+        if not self.started:
+            free_units = self.roles.get_types_from(self.unit_types, UnitTask.Idle, UnitTask.Moving, UnitTask.Gathering)
+            if len(free_units) >= self.unit_count:
+                # TODO: Better selection?
+                new_scouts = free_units.random_group_of(2)
+                self.units.extend(new_scouts)
+                self.scout_tags = new_scouts.tags
+
+                self.started = True
+        else:
+            scouts = self.roles.get_types_from(self.unit_types, UnitTask.Scouting)
+            self.units.extend(scouts.tags_in(self.scout_tags))
+            if not self.units:
+                # Scouts are dead, end the scout act
+                self.ended = True
+                return True
+
+        if self.units:
+            self.roles.set_tasks(UnitTask.Scouting, self.units)
+            count = len(self.orders)
+            self.index = self.index % count
+
+            for looped in range(0, count):
+                if looped == count:
+                    self.ended = True
+                    return True
+                # noinspection PyTypeChecker
+                action: ScoutBaseAction = self.orders[looped]
+                action.set_scouts(self.units)
+                result = await action.execute()
+                if not result:
+                    # Not finished
+                    return False
+        return False
+
+

--- a/sharpy/plans/tactics/scout.py
+++ b/sharpy/plans/tactics/scout.py
@@ -121,6 +121,7 @@ class ScoutLocation(ScoutBaseAction):
     def scout_own7() -> ScoutBaseAction:
         return ScoutLocation(lambda k: k.expansion_zones[6].center_location)
 
+
 class Scout(SubActs):
     units: Units
 

--- a/sharpy/plans/tactics/scout.py
+++ b/sharpy/plans/tactics/scout.py
@@ -130,7 +130,7 @@ class Scout(SubActs):
         Scout act for all races, loops the given scout actions
         @param unit_types: Types of units accepted as scouts
         @param unit_count: Units required to be used in scouting, scouting will only start after all are available
-        @param args: Scout actions, cen be to scout a certain location, or to move around in certain way
+        @param args: Scout actions, cen be to scout a certain location, or to move around in certain way. Defaults to scouting enemy main
         """
         if isinstance(unit_types, UnitTypeId):
             self.unit_types = set()

--- a/sharpy/plans/tactics/zerg/__init__.py
+++ b/sharpy/plans/tactics/zerg/__init__.py
@@ -3,4 +3,4 @@ from .plan_heat_overseer import PlanHeatOverseer
 from .spread_creep import SpreadCreep
 from .counter_terran_tie import CounterTerranTie
 from .overlord_scout import OverlordScout
-from .ling_scout import LingScoutMain
+from .ling_scout import LingScout

--- a/sharpy/plans/tactics/zerg/ling_scout.py
+++ b/sharpy/plans/tactics/zerg/ling_scout.py
@@ -1,39 +1,8 @@
-from typing import List, Optional
-
-from sc2.position import Point2
-from sc2.units import Units
-from sharpy.managers.roles import UnitTask
-from sharpy.plans.acts import ActBase
-from sc2 import UnitTypeId, AbilityId
-from sc2.ids.buff_id import BuffId
-from sc2.unit import Unit
+from sc2 import UnitTypeId
+from sharpy.plans.tactics import Scout
+from sharpy.plans.tactics.scout import ScoutBaseAction
 
 
-class LingScoutMain(ActBase):
-    def __init__(self):
-        self.scout_tags: List[int] = []
-        super().__init__()
-
-    async def start(self, knowledge: "Knowledge"):
-        return await super().start(knowledge)
-
-    async def execute(self) -> bool:
-        lings = self.cache.own(UnitTypeId.ZERGLING)
-        scouts = self.roles.all_from_task(UnitTask.Scouting)
-        scout_lings = lings.tags_in(scouts.tags)
-        non_scout_lings = lings.tags_not_in(scouts.tags)
-
-        if len(self.scout_tags) > 0 and not len(scout_lings) == 0:
-            return True
-
-        if len(self.scout_tags) == 0 and non_scout_lings.amount > 2:
-            scout_lings = Units(non_scout_lings[0:1], self.ai)
-            self.scout_tags = scout_lings.tags
-
-        for scout in scout_lings:
-            self.knowledge.roles.set_task(UnitTask.Scouting, scout)
-            target = self.knowledge.expansion_zones[-1].behind_mineral_position_center
-
-            self.do(scout.move(target))
-
-        return True
+class LingScout(Scout):
+    def __init__(self, unit_count: int = 2, *args: ScoutBaseAction):
+        super().__init__(UnitTypeId.ZERGLING, unit_count, *args)

--- a/sharpy/plans/tactics/zerg/overlord_scout.py
+++ b/sharpy/plans/tactics/zerg/overlord_scout.py
@@ -1,51 +1,10 @@
 from typing import List, Optional
 
 from sc2.position import Point2
-from sharpy.managers.roles import UnitTask
-from sharpy.plans.acts import ActBase
 from sc2 import UnitTypeId, AbilityId
-from sc2.ids.buff_id import BuffId
-from sc2.unit import Unit
+from sharpy.plans.tactics.scout import ScoutBaseAction, Scout
 
 
-class OverlordScout(ActBase):
-    def __init__(self):
-        self.first_scout: Optional[int] = None
-        self.second_scout: Optional[int] = None
-        super().__init__()
-
-    async def start(self, knowledge: "Knowledge"):
-        return await super().start(knowledge)
-
-    async def execute(self) -> bool:
-        overlords = self.cache.own(UnitTypeId.OVERLORD)
-        scouts = self.roles.all_from_task(UnitTask.Scouting)
-        overlords = overlords.tags_not_in(scouts.tags)
-
-        if not self.first_scout:
-            if overlords:
-                self.first_scout = overlords.first.tag
-        elif not self.second_scout:
-            if overlords:
-                self.second_scout = overlords.first.tag
-
-        if self.first_scout:
-            first = self.cache.by_tag(self.first_scout)
-            if first:
-                self.knowledge.roles.set_task(UnitTask.Scouting, first)
-                # TODO: Make it into a more likely proxy location
-                target = self.knowledge.expansion_zones[2].center_location
-                final_target: Point2 = self.knowledge.expansion_zones[-2].center_location
-                final_target = final_target.towards(self.ai.start_location, 9)
-
-                if self.knowledge.iteration == 0:  # first.distance_to(target) > 5:
-                    self.do(first.move(target))
-                    self.do(first.move(final_target, queue=True))
-        if self.second_scout:
-            second = self.cache.by_tag(self.first_scout)
-            if second:
-                final_target: Point2 = self.knowledge.expansion_zones[1].center_location
-                if second.is_idle and second.distance_to(final_target) > 10:
-                    self.do(second.move(final_target))
-
-        return True
+class OverlordScout(Scout):
+    def __init__(self, *args: ScoutBaseAction):
+        super().__init__(UnitTypeId.OVERLORD, 1, *args)


### PR DESCRIPTION
Draft for doing generic scouting in sharpy with all unit types

New syntax is creating a new scout path by adding `Scout`, `UnitTypeId`, amount of units and scouting acts
`Scout(UnitTypeId.OVERLORD, 1, ScoutLocation.scout_enemy2(), ScoutLocation.scout_enemy3())`