### PR TITLE
Version manager and manager extensions

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,7 +1,7 @@
 [pytest]
 
 # Ignore these folders
-norecursedirs = venv python-sc2
+norecursedirs = venv python-sc2 publish Bots
 
 # Add these folders to PYTHONPATH - this requires pytest-pythonpath plugin to work!
 python_paths = ./ ./python-sc2

--- a/sharpy/knowledges/knowledge.py
+++ b/sharpy/knowledges/knowledge.py
@@ -68,8 +68,10 @@ class Knowledge:
         self.chat_manager: ChatManager = ChatManager()
         self.memory_manager: MemoryManager = MemoryManager()
         self.action_handler: ActionHandler = ActionHandler()
+        self.version_manager: VersionManager = VersionManager()
 
         self.managers: List[ManagerBase] = [
+            self.version_manager,
             self.unit_values,
             self.unit_cache,
             self.action_handler,

--- a/sharpy/knowledges/knowledge.py
+++ b/sharpy/knowledges/knowledge.py
@@ -17,13 +17,17 @@ from sc2.data import Result
 from sc2.position import Point2
 from sc2.unit import Unit
 from sc2.units import Units
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from sharpy.knowledges import KnowledgeBot
 
 root_logger = logging.getLogger()
 
 
 class Knowledge:
     def __init__(self):
-        self.ai: sc2.BotAI = None
+        self.ai: "KnowledgeBot" = None
         self.config: ConfigParser = None
         self._debug: bool = False
 
@@ -69,7 +73,14 @@ class Knowledge:
         self.memory_manager: MemoryManager = MemoryManager()
         self.action_handler: ActionHandler = ActionHandler()
         self.version_manager: VersionManager = VersionManager()
+        self.managers: List[ManagerBase] = []
 
+    def set_managers(self, additional_managers: Optional[List[ManagerBase]]):
+        """
+        Sets managers to be updated
+        @param additional_managers: Additional list of custom managers
+        @return: None
+        """
         self.managers: List[ManagerBase] = [
             self.version_manager,
             self.unit_values,
@@ -93,9 +104,14 @@ class Knowledge:
             self.memory_manager,
         ]
 
+        if additional_managers:
+            self.managers.extend(additional_managers)
+
     # noinspection PyAttributeOutsideInit
-    def pre_start(self, ai: sc2.BotAI):
-        self.ai: sc2.BotAI = ai
+    def pre_start(self, ai: "KnowledgeBot", additional_managers: Optional[List[ManagerBase]]):
+        assert isinstance(ai, sc2.BotAI)
+        self.ai: "KnowledgeBot" = ai
+        self.set_managers(additional_managers)
         self._all_own: Units = Units([], self.ai)
         self.config: ConfigParser = self.ai.config
         self.logger = sc2.main.logger

--- a/sharpy/knowledges/knowledge_bot.py
+++ b/sharpy/knowledges/knowledge_bot.py
@@ -5,9 +5,10 @@ from abc import abstractmethod
 
 from sc2.units import Units
 from sharpy.knowledges import Knowledge
+from sharpy.managers import ManagerBase
 from sharpy.plans import BuildOrder
 from config import get_config, get_version
-from sc2 import BotAI, Result, Optional, UnitTypeId
+from sc2 import BotAI, Result, Optional, UnitTypeId, List
 from sc2.unit import Unit
 import time
 
@@ -31,13 +32,21 @@ class KnowledgeBot(BotAI):
         self.unit_command_uses_self_do = True
 
     async def real_init(self):
-        self.knowledge.pre_start(self)
+        self.knowledge.pre_start(self, self.configure_managers())
         await self.knowledge.start()
         self.plan = await self.create_plan()
         if self.start_plan:
             await self.plan.start(self.knowledge)
 
         self._log_start()
+
+    def configure_managers(self) -> Optional[List[ManagerBase]]:
+        """
+        Override this for custom manager usage.
+        Use this to override managers in knowledge
+        @return: Optional list of new managers
+        """
+        return None
 
     async def chat_init(self):
         if self.knowledge.is_chat_allowed:

--- a/sharpy/managers/__init__.py
+++ b/sharpy/managers/__init__.py
@@ -17,3 +17,4 @@ from .chat_manager import ChatManager
 from .memory_manager import MemoryManager
 from .action_issued import ActionHandler
 from .unit_value import UnitValue
+from .version_manager import VersionManager

--- a/sharpy/managers/version_manager.py
+++ b/sharpy/managers/version_manager.py
@@ -10,6 +10,7 @@ VERSION_4_11_4 = 78285
 VERSION_4_11_0 = 77379
 VERSION_4_10_0 = 75689
 
+
 class VersionManager(ManagerBase):
     def __init__(self):
         self.short_version = "0.0.0"
@@ -41,7 +42,8 @@ class VersionManager(ManagerBase):
 
     def configure_enums(self):
         if self.base_version == VERSION_4_10_0:
-            self._set_enum_mapping(UnitTypeId,
+            self._set_enum_mapping(
+                UnitTypeId,
                 {
                     UnitTypeId.ASSIMILATORRICH: 1955,
                     UnitTypeId.EXTRACTORRICH: 1956,
@@ -49,8 +51,8 @@ class VersionManager(ManagerBase):
                     UnitTypeId.INHIBITORZONEMEDIUM: 1958,
                     UnitTypeId.INHIBITORZONELARGE: 1959,
                     UnitTypeId.REFINERYRICH: 1960,
-                    UnitTypeId.MINERALFIELD450: 1961
-                }
+                    UnitTypeId.MINERALFIELD450: 1961,
+                },
             )
 
     def _set_enum_mapping(self, enum: Any, items: Dict[Any, int]):

--- a/sharpy/managers/version_manager.py
+++ b/sharpy/managers/version_manager.py
@@ -1,0 +1,69 @@
+from enum import Enum
+from typing import Set, Dict, Any, Type
+
+from sc2 import UnitTypeId
+from sc2.ids.upgrade_id import UpgradeId
+from sc2.protocol import Protocol
+from sharpy.managers import ManagerBase
+
+VERSION_4_11_4 = 78285
+VERSION_4_11_0 = 77379
+VERSION_4_10_0 = 75689
+
+class VersionManager(ManagerBase):
+    def __init__(self):
+        self.short_version = "0.0.0"
+        self.full_version = "0.0.0.12345"
+        self.base_version = 12345
+        self.disabled_upgrades: Set[UpgradeId] = set()
+        self.moved_upgrades: Dict[UpgradeId, UnitTypeId] = {}
+        super().__init__()
+
+    async def start(self, knowledge: "Knowledge"):
+        await super().start(knowledge)
+        response = await self.client.ping()
+        self.full_version = response.ping.game_version
+        self.base_version = response.ping.base_build
+        splits = response.ping.game_version.split(".")
+
+        if len(splits) == 4:
+            self.short_version = f"{splits[0]}.{splits[1]}.{splits[2]}"
+
+        self.knowledge.print(self.full_version, "Version")
+        self.configure_enums()
+        self.configure_upgrades()
+
+    async def update(self):
+        pass
+
+    async def post_update(self):
+        pass
+
+    def configure_enums(self):
+        if self.base_version == VERSION_4_10_0:
+            self._set_enum_mapping(UnitTypeId,
+                {
+                    UnitTypeId.ASSIMILATORRICH: 1955,
+                    UnitTypeId.EXTRACTORRICH: 1956,
+                    UnitTypeId.INHIBITORZONESMALL: 1957,
+                    UnitTypeId.INHIBITORZONEMEDIUM: 1958,
+                    UnitTypeId.INHIBITORZONELARGE: 1959,
+                    UnitTypeId.REFINERYRICH: 1960,
+                    UnitTypeId.MINERALFIELD450: 1961
+                }
+            )
+
+    def _set_enum_mapping(self, enum: Any, items: Dict[Any, int]):
+        for enum_key, value in items.items():
+            enum_key._value_ = value
+            enum._member_map_[enum_key.name] = value
+            enum._value2member_map_[value] = enum_key
+            self.print(f"Setting {enum_key.name} to {enum_key.value}")
+
+    def configure_upgrades(self):
+        if self.base_version < VERSION_4_11_0:
+            self.disabled_upgrades.add(UpgradeId.LURKERRANGE)
+            self.disabled_upgrades.add(UpgradeId.MICROBIALSHROUD)
+            self.disabled_upgrades.add(UpgradeId.VOIDRAYSPEEDUPGRADE)
+            self.moved_upgrades[UpgradeId.MEDIVACINCREASESPEEDBOOST] = UnitTypeId.STARPORTTECHLAB
+            self.moved_upgrades[UpgradeId.LIBERATORAGRANGEUPGRADE] = UnitTypeId.STARPORTTECHLAB

--- a/sharpy/plans/acts/act_tech_test.py
+++ b/sharpy/plans/acts/act_tech_test.py
@@ -6,6 +6,7 @@ from sc2.ids.upgrade_id import UpgradeId
 
 from .act_tech import ActTech
 
+
 def mock_knowledge() -> mock.Mock:
     knowledge_mock = mock.Mock()
     knowledge_mock.get_boolean_setting = lambda x: False
@@ -13,6 +14,7 @@ def mock_knowledge() -> mock.Mock:
     knowledge_mock.version_manager.moved_upgrades = {}
     knowledge_mock.version_manager.disabled_upgrades = {UpgradeId.LURKERRANGE}
     return knowledge_mock
+
 
 class TestActTech:
     @pytest.mark.asyncio

--- a/sharpy/plans/acts/act_tech_test.py
+++ b/sharpy/plans/acts/act_tech_test.py
@@ -1,19 +1,47 @@
+import pytest
+from unittest import mock
+
 from sc2 import UnitTypeId
 from sc2.ids.upgrade_id import UpgradeId
 
 from .act_tech import ActTech
 
+def mock_knowledge() -> mock.Mock:
+    knowledge_mock = mock.Mock()
+    knowledge_mock.get_boolean_setting = lambda x: False
+    knowledge_mock.ai._client = mock.Mock()
+    knowledge_mock.version_manager.moved_upgrades = {}
+    knowledge_mock.version_manager.disabled_upgrades = {UpgradeId.LURKERRANGE}
+    return knowledge_mock
 
 class TestActTech:
-    def test_SPIRE_and_GREATERSPIRE_found_implicitly_for_ZERGFLYERWEAPONSLEVEL2(self):
+    @pytest.mark.asyncio
+    async def test_SPIRE_and_GREATERSPIRE_found_implicitly_for_ZERGFLYERWEAPONSLEVEL2(self):
         act_tech = ActTech(UpgradeId.ZERGFLYERWEAPONSLEVEL2)
+        await act_tech.start(mock_knowledge())
 
         assert UnitTypeId.SPIRE in act_tech.from_buildings
         assert UnitTypeId.GREATERSPIRE in act_tech.from_buildings
         assert 2 == len(act_tech.from_buildings)
 
-    def test_ROACHWARREN_found_implicitly_for_GLIALRECONSTITUTION(self):
+    @pytest.mark.asyncio
+    async def test_ROACHWARREN_found_implicitly_for_GLIALRECONSTITUTION(self):
         act_tech = ActTech(UpgradeId.GLIALRECONSTITUTION)
+        await act_tech.start(mock_knowledge())
 
         assert UnitTypeId.ROACHWARREN in act_tech.from_buildings
         assert 1 == len(act_tech.from_buildings)
+
+    @pytest.mark.asyncio
+    async def test_LURKERRANGE_disabled_in_VersionManager(self):
+        act_tech = ActTech(UpgradeId.LURKERRANGE)
+        await act_tech.start(mock_knowledge())
+
+        assert not act_tech.enabled
+
+    @pytest.mark.asyncio
+    async def test_TERRANVEHICLEANDSHIPARMORSLEVEL3_enabled_in_VersionManager(self):
+        act_tech = ActTech(UpgradeId.TERRANVEHICLEANDSHIPARMORSLEVEL3)
+        await act_tech.start(mock_knowledge())
+
+        assert act_tech.enabled

--- a/sharpy/plans/acts/protoss/restore_power.py
+++ b/sharpy/plans/acts/protoss/restore_power.py
@@ -6,12 +6,21 @@ from sc2 import UnitTypeId, Race
 from sc2.position import Point2
 from sc2.unit import Unit
 
-# These buildings do not need to be powered by pylons.
-ignored_building_types = (
-    UnitTypeId.PYLON,
-    UnitTypeId.NEXUS,
-    UnitTypeId.ASSIMILATOR,
-    UnitTypeId.ASSIMILATORRICH,
+# These buildings need to be powered by pylons.
+building_types = (
+    UnitTypeId.GATEWAY,
+    UnitTypeId.WARPGATE,
+    UnitTypeId.FORGE,
+    UnitTypeId.PHOTONCANNON,
+    UnitTypeId.SHIELDBATTERY,
+    UnitTypeId.CYBERNETICSCORE,
+    UnitTypeId.TWILIGHTCOUNCIL,
+    UnitTypeId.ROBOTICSFACILITY,
+    UnitTypeId.STARGATE,
+    UnitTypeId.TEMPLARARCHIVE,
+    UnitTypeId.DARKSHRINE,
+    UnitTypeId.ROBOTICSBAY,
+    UnitTypeId.FLEETBEACON,
 )
 
 
@@ -63,7 +72,7 @@ class RestorePower(ActBase):
         """Returns all of our unpowered buildings on the map."""
         structures = self.ai.structures
         unpowered = filter(
-            lambda s: not s.is_powered and s.build_progress == 1 and s.type_id not in ignored_building_types, structures
+            lambda s: not s.is_powered and s.build_progress == 1 and s.type_id in building_types, structures
         )
         return list(unpowered)
 


### PR DESCRIPTION
## Version manager added to handle differences between versions.
- Linux version can correctly handle changed UnitTypeId value for rich mining buildings.
- ActTech can disable itself when there is an upgrade that isn't supported in the current version and adjust to upgrades that have moved
- Fixed restore power to be more resilient to different versions

## Extending managers
- New interface for overriding existing managers and adding new ones