### PR TITLE
 ref https://github.com/DrInfy/sharpy-sc2/issues/54

### DIFF
--- a/dummies/terran/rusty.py
+++ b/dummies/terran/rusty.py
@@ -1,6 +1,3 @@
-from typing import List, Optional
-
-from sharpy.managers import DataManager, ManagerBase
 from sharpy.plans.acts import *
 from sharpy.plans.acts.terran import *
 from sharpy.plans.require import *
@@ -141,54 +138,10 @@ class BuildTanks(BuildOrder):
 
         super().__init__([scv, dt_counter, dt_counter2, self.depots, buildings, mech, air, marines])
 
-class LarvaManager(ManagerBase):
-    def __init__(self):
-        super().__init__()
-        self._larva = 0
-
-    @property
-    def larva_count(self) -> int:
-        return self._larva
-
-    async def update(self):
-        # This is being run each frame
-        self._larva = len(self.cache.own(UnitTypeId.LARVA))
-
-    async def post_update(self):
-        # This manager doesn't need to do anything at the end of the frame.
-        pass
-
-class MyDataManager(DataManager):
-    """ Simple replacement to data manager """
-
-    def select_build(self, available_builds: List[str]) -> str:
-        """ Selects last build if it won and another if it didn't win. """
-        if len(available_builds) == 1:
-            return available_builds[0]
-        assert len(available_builds) > 1
-
-        last = self.last_result
-        if last is not None and last.build_used in available_builds:
-            if last.result > 0:
-                return last
-            available_builds.remove(last)
-
-        return available_builds[random.randint(0, len(available_builds) - 1)]
 
 class Rusty(KnowledgeBot):
     def __init__(self):
         super().__init__("Old Rusty")
-
-    def configure_managers(self) -> Optional[List[ManagerBase]]:
-        # override built in data manager
-        self.data_manager = MyDataManager()
-        self.knowledge.data_manager = self.data_manager
-
-        # add our own custom manager
-        self.larva_manager = LarvaManager()
-        self.knowledge.larva_manager = self.larva_manager
-        self.knowledge.set_managers(additional_managers=[self.larva_manager])
-
 
     async def pre_step_execute(self):
         pass

--- a/sharpy/knowledges/knowledge.py
+++ b/sharpy/knowledges/knowledge.py
@@ -54,7 +54,7 @@ class Knowledge:
         self._on_unit_destroyed_listeners: List[Callable] = list()
 
         # Managers
-        self.manager_dict = {}
+        self.manager_dict = dict()
         self.unit_cache: UnitCacheManager = UnitCacheManager()
         self.zone_manager: ZoneManager = ZoneManager()
         self.enemy_units_manager: EnemyUnitsManager = EnemyUnitsManager()

--- a/sharpy/knowledges/knowledge.py
+++ b/sharpy/knowledges/knowledge.py
@@ -54,6 +54,7 @@ class Knowledge:
         self._on_unit_destroyed_listeners: List[Callable] = list()
 
         # Managers
+        self.manager_dict = {}
         self.unit_cache: UnitCacheManager = UnitCacheManager()
         self.zone_manager: ZoneManager = ZoneManager()
         self.enemy_units_manager: EnemyUnitsManager = EnemyUnitsManager()
@@ -81,31 +82,36 @@ class Knowledge:
         @param additional_managers: Additional list of custom managers
         @return: None
         """
-        self.managers: List[ManagerBase] = [
-            self.version_manager,
-            self.unit_values,
-            self.unit_cache,
-            self.action_handler,
-            self.pathing_manager,
-            self.zone_manager,
-            self.enemy_units_manager,
-            self.cooldown_manager,
-            self.building_solver,
-            self.income_calculator,
-            self.roles,
-            self.build_detector,
-            self.enemy_army_predicter,
-            self.lost_units_manager,
-            self.game_analyzer,
-            self.combat_manager,
-            self.chat_manager,
-            self.previous_units_manager,
-            self.data_manager,
-            self.memory_manager,
-        ]
+        if len(self.manager_dict) > 0:
+            self.managers = [manager for manager in self.manager_dict.values()]
+        else:
+            self.managers: List[ManagerBase] = [
+                self.version_manager,
+                self.unit_values,
+                self.unit_cache,
+                self.action_handler,
+                self.pathing_manager,
+                self.zone_manager,
+                self.enemy_units_manager,
+                self.cooldown_manager,
+                self.building_solver,
+                self.income_calculator,
+                self.roles,
+                self.build_detector,
+                self.enemy_army_predicter,
+                self.lost_units_manager,
+                self.game_analyzer,
+                self.combat_manager,
+                self.chat_manager,
+                self.previous_units_manager,
+                self.data_manager,
+                self.memory_manager,
+            ]
 
         if additional_managers:
             self.managers.extend(additional_managers)
+        for manager in self.managers:
+            self.manager_dict[manager] = manager
 
     # noinspection PyAttributeOutsideInit
     def pre_start(self, ai: "KnowledgeBot", additional_managers: Optional[List[ManagerBase]]):


### PR DESCRIPTION
 **`knowledge.py`** 
* added attribute self.manager_dict
* modified `set_managers` to account for the dict
  assuming `MyManager` is a manager, it could be accessed like so
 `knowledge.manager_dict[type(MyManager)]`





* modified ( and simplified? )  `configure_managers` usage 


```python
 def configure_managers(self) -> Optional[List[ManagerBase]]:
        # override built in data manager
        self.data_manager = MyDataManager()
        self.knowledge.data_manager = self.data_manager

        # add our own custom manager
        self.larva_manager = LarvaManager()
        self.knowledge.larva_manager = self.larva_manager
        self.knowledge.set_managers(additional_managers=[self.larva_manager])

        return None  # Do not add overriding managers to additional managers

```