### PR TITLE
Added a get_manager method that returns manager by its type or subtype

### DIFF
--- a/sharpy/knowledges/knowledge.py
+++ b/sharpy/knowledges/knowledge.py
@@ -1,7 +1,7 @@
 import logging
 import string
 from configparser import ConfigParser
-from typing import Set, List, Optional, Dict, Callable
+from typing import Set, List, Optional, Dict, Callable, Type
 
 import sc2
 from sharpy.general.zone import Zone
@@ -17,13 +17,13 @@ from sc2.data import Result
 from sc2.position import Point2
 from sc2.unit import Unit
 from sc2.units import Units
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, TypeVar
 
 if TYPE_CHECKING:
     from sharpy.knowledges import KnowledgeBot
 
 root_logger = logging.getLogger()
-
+TManager = TypeVar('TManager')
 
 class Knowledge:
     def __init__(self):
@@ -106,6 +106,16 @@ class Knowledge:
 
         if additional_managers:
             self.managers.extend(additional_managers)
+
+    def get_manager(self, manager_type: Type[TManager]) -> TManager:
+        """
+
+        @param manager_type:
+        @return:
+        """
+        for manager in self.managers:
+            if issubclass(type(manager), manager_type):
+                return manager
 
     # noinspection PyAttributeOutsideInit
     def pre_start(self, ai: "KnowledgeBot", additional_managers: Optional[List[ManagerBase]]):

--- a/sharpy/knowledges/knowledge.py
+++ b/sharpy/knowledges/knowledge.py
@@ -23,7 +23,8 @@ if TYPE_CHECKING:
     from sharpy.knowledges import KnowledgeBot
 
 root_logger = logging.getLogger()
-TManager = TypeVar('TManager')
+TManager = TypeVar("TManager")
+
 
 class Knowledge:
     def __init__(self):

--- a/sharpy/knowledges/knowledge.py
+++ b/sharpy/knowledges/knowledge.py
@@ -76,11 +76,13 @@ class Knowledge:
         self.version_manager: VersionManager = VersionManager()
         self.managers: List[ManagerBase] = []
 
-    def set_managers(self, additional_managers: Optional[List[ManagerBase]]):
+    def _set_managers(self, additional_managers: Optional[List[ManagerBase]]):
         """
-        Sets managers to be updated
+        Sets managers to be updated.
+        This is not intended to be used outside of Knowledge.
+        Use KnowledgeBot.configure_managers to configure your managers.
+
         @param additional_managers: Additional list of custom managers
-        @return: None
         """
         self.managers: List[ManagerBase] = [
             self.version_manager,
@@ -108,11 +110,13 @@ class Knowledge:
         if additional_managers:
             self.managers.extend(additional_managers)
 
-    def get_manager(self, manager_type: Type[TManager]) -> TManager:
+    def get_manager(self, manager_type: Type[TManager]) -> Optional[TManager]:
         """
+        Get manager by its type. Because the implementation can pretty slow, it is recommended to
+        fetch the required manager types in Component `start` in order to not slow the bot down.
 
-        @param manager_type:
-        @return:
+        @param manager_type: type of manager to be requested. i.e. `DataManager`
+        @return: Manager of requested type, if one is found.
         """
         for manager in self.managers:
             if issubclass(type(manager), manager_type):
@@ -122,7 +126,7 @@ class Knowledge:
     def pre_start(self, ai: "KnowledgeBot", additional_managers: Optional[List[ManagerBase]]):
         assert isinstance(ai, sc2.BotAI)
         self.ai: "KnowledgeBot" = ai
-        self.set_managers(additional_managers)
+        self._set_managers(additional_managers)
         self._all_own: Units = Units([], self.ai)
         self.config: ConfigParser = self.ai.config
         self.logger = sc2.main.logger

--- a/sharpy/knowledges/knowledge_bot.py
+++ b/sharpy/knowledges/knowledge_bot.py
@@ -65,7 +65,7 @@ class KnowledgeBot(BotAI):
 
         return msg
 
-    async def chat_send(self, message: str):
+    async def chat_send(self, message: str, team_only: bool = False):
         # todo: refactor to use chat manager?
         self.knowledge.print(message, "Chat")
         await super().chat_send(message)

--- a/sharpy/knowledges/knowledge_test.py
+++ b/sharpy/knowledges/knowledge_test.py
@@ -26,7 +26,7 @@ class TestKnowledge:
     @pytest.mark.asyncio
     async def test_get_DataManager(self):
         knowledge = Knowledge()
-        knowledge.set_managers(None)
+        knowledge._set_managers(None)
 
         data_manager = knowledge.get_manager(DataManager)
 
@@ -37,7 +37,7 @@ class TestKnowledge:
     async def test_get_DataManager_from_override(self):
         knowledge = Knowledge()
         knowledge.data_manager = TestDataManager()
-        knowledge.set_managers(None)
+        knowledge._set_managers(None)
 
         data_manager = knowledge.get_manager(DataManager)
 
@@ -49,7 +49,7 @@ class TestKnowledge:
     async def test_get_TestDataManager_from_override(self):
         knowledge = Knowledge()
         knowledge.data_manager = TestDataManager()
-        knowledge.set_managers(None)
+        knowledge._set_managers(None)
 
         data_manager = knowledge.get_manager(TestDataManager)
 
@@ -61,7 +61,7 @@ class TestKnowledge:
     @pytest.mark.asyncio
     async def test_get_CustomManager_from_override(self):
         knowledge = Knowledge()
-        knowledge.set_managers([CustomTestManager()])
+        knowledge._set_managers([CustomTestManager()])
 
         custom_manager = knowledge.get_manager(CustomTestManager)
 
@@ -73,7 +73,7 @@ class TestKnowledge:
     @pytest.mark.asyncio
     async def test_get_None_CustomManager_not_set(self):
         knowledge = Knowledge()
-        knowledge.set_managers(None)
+        knowledge._set_managers(None)
 
         custom_manager = knowledge.get_manager(CustomTestManager)
 

--- a/sharpy/knowledges/knowledge_test.py
+++ b/sharpy/knowledges/knowledge_test.py
@@ -1,0 +1,80 @@
+import pytest
+from unittest import mock
+
+from sharpy.knowledges import Knowledge
+from sharpy.managers import DataManager, ManagerBase
+
+
+class TestDataManager(DataManager):
+    def should_be_true(self) -> bool:
+        return self.debug == False
+
+
+class CustomTestManager(ManagerBase):
+    @property
+    def test_property(self) -> int:
+        return 1
+
+    async def update(self):
+        pass
+
+    async def post_update(self):
+        pass
+
+
+class TestKnowledge:
+    @pytest.mark.asyncio
+    async def test_get_DataManager(self):
+        knowledge = Knowledge()
+        knowledge.set_managers(None)
+
+        data_manager = knowledge.get_manager(DataManager)
+
+        assert data_manager is not None
+        assert isinstance(data_manager, DataManager)
+
+    @pytest.mark.asyncio
+    async def test_get_DataManager_from_override(self):
+        knowledge = Knowledge()
+        knowledge.data_manager = TestDataManager()
+        knowledge.set_managers(None)
+
+        data_manager = knowledge.get_manager(DataManager)
+
+        assert data_manager is not None
+        assert isinstance(data_manager, TestDataManager)
+        assert isinstance(data_manager, DataManager)
+
+    @pytest.mark.asyncio
+    async def test_get_TestDataManager_from_override(self):
+        knowledge = Knowledge()
+        knowledge.data_manager = TestDataManager()
+        knowledge.set_managers(None)
+
+        data_manager = knowledge.get_manager(TestDataManager)
+
+        assert data_manager is not None
+        assert isinstance(data_manager, TestDataManager)
+        assert isinstance(data_manager, DataManager)
+        assert data_manager.should_be_true()
+
+    @pytest.mark.asyncio
+    async def test_get_CustomManager_from_override(self):
+        knowledge = Knowledge()
+        knowledge.set_managers([CustomTestManager()])
+
+        custom_manager = knowledge.get_manager(CustomTestManager)
+
+        assert custom_manager is not None
+        assert isinstance(custom_manager, CustomTestManager)
+        assert isinstance(custom_manager, ManagerBase)
+        assert custom_manager.test_property == 1
+
+    @pytest.mark.asyncio
+    async def test_get_None_CustomManager_not_set(self):
+        knowledge = Knowledge()
+        knowledge.set_managers(None)
+
+        custom_manager = knowledge.get_manager(CustomTestManager)
+
+        assert custom_manager is None

--- a/sharpy/knowledges/knowledge_test.py
+++ b/sharpy/knowledges/knowledge_test.py
@@ -7,7 +7,7 @@ from sharpy.managers import DataManager, ManagerBase
 
 class TestDataManager(DataManager):
     def should_be_true(self) -> bool:
-        return self.debug == False
+        return self.debug is False
 
 
 class CustomTestManager(ManagerBase):


### PR DESCRIPTION
Added a method from getting managers by their type from the `Knowledge` class.

Attempts to solve #54 with as few breaking changes as possible and having proper generic type return from requesting the manager by its type.

Unit tests included.

Compatible with all old syntax, but includes a new one for getting managers.
```py
data_manager = knowledge.get_manager(DataManager)
```
