### PR TITLE
micro rules class allows more micro customization

### DIFF
--- a/dummies/zerg/macro_zerg_v2.py
+++ b/dummies/zerg/macro_zerg_v2.py
@@ -1,3 +1,6 @@
+from typing import Optional, List
+
+from sharpy.managers import ManagerBase
 from sharpy.plans.acts import *
 from sharpy.plans.acts.zerg import *
 from sharpy.plans.require import *
@@ -63,6 +66,10 @@ class MacroZergV2(KnowledgeBot):
 
     def __init__(self):
         super().__init__("Macro zerg")
+
+    def configure_managers(self) -> Optional[List[ManagerBase]]:
+        self.knowledge.combat_manager.default_rules.regroup = False
+        return None
 
     async def create_plan(self) -> BuildOrder:
         attack = PlanZoneAttack(120)

--- a/sharpy/general/component.py
+++ b/sharpy/general/component.py
@@ -28,12 +28,14 @@ class Component:
 
     def __init__(self) -> None:
         self._debug: bool = False
+        self._started: bool = False
 
     @property
     def debug(self):
         return self._debug and self.knowledge.debug
 
     async def start(self, knowledge: "Knowledge"):
+        self._started = True
         self.knowledge = knowledge
         self._debug = self.knowledge.get_boolean_setting(f"debug.{type(self).__name__}")
         self.ai = knowledge.ai

--- a/sharpy/managers/combat2/__init__.py
+++ b/sharpy/managers/combat2/__init__.py
@@ -5,3 +5,4 @@ from .action import Action, NoAction
 from .move_type import MoveType
 from .no_micro import NoMicro
 from .micro_workers import MicroWorkers
+from .micro_rules import MicroRules

--- a/sharpy/managers/combat2/default_micro_methods.py
+++ b/sharpy/managers/combat2/default_micro_methods.py
@@ -38,7 +38,7 @@ class DefaultMicroMethods:
                     combat.move_to(group, target, move_type)
                 else:
                     combat.attack_to(group, target, move_type)
-                return
+                continue
 
             center = group.center
             closest_enemies = group.closest_target_group(combat.enemy_groups)

--- a/sharpy/managers/combat2/default_micro_methods.py
+++ b/sharpy/managers/combat2/default_micro_methods.py
@@ -112,7 +112,7 @@ class DefaultMicroMethods:
             step.closest_group_distance = 100000
         step.enemy_groups = enemy_groups
         step.center = units.center
-        step.enemies_near_by: Units = step.knowledge.unit_cache.enemy_in_range(step.center, 15 + len(group.units) * 0.1)
+        step.enemies_near_by = step.knowledge.unit_cache.enemy_in_range(step.center, 15 + len(group.units) * 0.1)
 
         step.engaged_power.add_units(step.enemies_near_by)
 

--- a/sharpy/managers/combat2/default_micro_methods.py
+++ b/sharpy/managers/combat2/default_micro_methods.py
@@ -1,0 +1,217 @@
+from abc import abstractmethod
+from typing import List, Optional, Dict, Callable
+
+from sc2 import UnitTypeId, Race, AbilityId
+from sc2.position import Point2
+from sc2.unit import Unit
+from sc2.units import Units
+from sharpy.managers.combat2 import CombatUnits, MoveType, MicroStep, Action
+
+changelings = {
+    UnitTypeId.CHANGELING,
+    UnitTypeId.CHANGELINGMARINE,
+    UnitTypeId.CHANGELINGMARINESHIELD,
+    UnitTypeId.CHANGELINGZEALOT,
+    UnitTypeId.CHANGELINGZERGLING,
+    UnitTypeId.CHANGELINGZERGLINGWINGS,
+}
+
+
+class DefaultMicroMethods:
+    @staticmethod
+    def init_micro_group(
+        step: MicroStep, group: CombatUnits, units: Units, enemy_groups: List[CombatUnits], move_type: MoveType
+    ):
+        ready_to_attack = 0
+
+        step.closest_group = group.closest_target_group(enemy_groups)
+        if step.closest_group:
+            step.closest_group_distance = group.center.distance_to(step.closest_group.center)
+        else:
+            step.closest_group_distance = 100000
+        step.enemy_groups = enemy_groups
+        step.center = units.center
+        step.enemies_near_by: Units = step.knowledge.unit_cache.enemy_in_range(step.center, 15 + len(group.units) * 0.1)
+
+        step.engaged_power.add_units(step.enemies_near_by)
+
+        engage_count = 0
+        can_engage_count = 0
+        step.attack_range = 0
+        step.enemy_attack_range = 0
+        attack_range_count = 0
+        enemy_attack_range_count = 0
+
+        for unit in units:
+            closest_distance = 1000
+            if step.ready_to_shoot(unit):
+                ready_to_attack += 1
+
+            engage_added = False
+            can_engage_added = False
+            for enemy_near in step.enemies_near_by:  # type: Unit
+                d = enemy_near.distance_to(unit)
+                if d < closest_distance:
+                    step.closest_units[unit.tag] = enemy_near
+                    closest_distance = d
+
+                att_range = step.unit_values.real_range(enemy_near, unit)
+                step.enemy_attack_range += att_range
+                enemy_attack_range_count += 1
+                if not engage_added and d < att_range:
+                    engage_count += 1
+                    engage_added = True
+
+                att_range = step.unit_values.real_range(unit, enemy_near)
+                step.attack_range += att_range
+                attack_range_count += 1
+
+                if not can_engage_added and d < att_range:
+                    can_engage_count += 1
+                    can_engage_added = True
+
+        if attack_range_count > 0:
+            step.attack_range = step.attack_range / attack_range_count
+
+        if enemy_attack_range_count > 0:
+            step.enemy_attack_range = step.enemy_attack_range / enemy_attack_range_count
+
+        step.ready_to_attack_ratio = ready_to_attack / len(units)
+        step.engage_ratio = engage_count / len(units)
+        step.can_engage_ratio = can_engage_count / len(units)
+
+    @staticmethod
+    def focus_fire(
+        step: MicroStep, unit: Unit, current_command: Action, prio: Optional[Dict[UnitTypeId, int]]
+    ) -> Action:
+        shoot_air = step.unit_values.can_shoot_air(unit)
+        shoot_ground = step.unit_values.can_shoot_ground(unit)
+
+        air_range = step.unit_values.air_range(unit)
+        ground_range = step.unit_values.ground_range(unit)
+        lookup = min(air_range + 3, ground_range + 3)
+        enemies = step.cache.enemy_in_range(unit.position, lookup)
+
+        last_target = step.last_targeted(unit)
+
+        if not enemies:
+            # No enemies to shoot at
+            return current_command
+
+        value_func: Callable[[Unit], float]
+        if prio:
+            value_func = (
+                lambda u: 1 if u.type_id in changelings else prio.get(u.type_id, -1) * (1 - u.shield_health_percentage)
+            )
+        else:
+            value_func = (
+                lambda u: 1
+                if u.type_id in changelings
+                else 2 * step.unit_values.power_by_type(u.type_id, 1 - u.shield_health_percentage)
+            )
+
+        best_target: Optional[Unit] = None
+        best_score: float = 0
+        for enemy in enemies:  # type: Unit
+            if not step.is_target(enemy):
+                continue
+
+            if not shoot_air and enemy.is_flying:
+                continue
+
+            if not shoot_ground and not enemy.is_flying:
+                continue
+
+            pos: Point2 = enemy.position
+            score = value_func(enemy) + (1 - pos.distance_to(unit) / lookup)
+            if enemy.tag == last_target:
+                score += 3
+
+            if step.focus_fired.get(enemy.tag, 0) > enemy.health:
+                score *= 0.1
+
+            if score > best_score:
+                best_target = enemy
+                best_score = score
+
+        if best_target:
+            step.focus_fired[best_target.tag] = (
+                step.focus_fired.get(best_target.tag, 0) + unit.calculate_damage_vs_target(best_target)[0]
+            )
+
+            return Action(best_target, True)
+
+        return current_command
+
+    @staticmethod
+    def melee_focus_fire(
+        step: MicroStep, unit: Unit, current_command: Action, prio: Optional[Dict[UnitTypeId, int]]
+    ) -> Action:
+        ground_range = step.unit_values.ground_range(unit)
+        lookup = ground_range + 3
+        enemies = step.cache.enemy_in_range(unit.position, lookup)
+
+        last_target = step.last_targeted(unit)
+
+        if not enemies:
+            # No enemies to shoot at
+            return current_command
+
+        def melee_value(u: Unit):
+            val = 1 - u.shield_health_percentage
+            range = step.unit_values.real_range(unit, u)
+            if unit.distance_to(u) < range:
+                val += 2
+            if step.knowledge.enemy_race == Race.Terran and unit.is_structure and unit.build_progress < 1:
+                # if building isn't finished, focus on the possible scv instead
+                val -= 2
+            return val
+
+        value_func = melee_value
+        close_enemies = step.cache.enemy_in_range(unit.position, lookup)
+
+        best_target: Optional[Unit] = None
+        best_score: float = 0
+
+        for enemy in close_enemies:  # type: Unit
+            if enemy.is_flying:
+                continue
+
+            pos: Point2 = enemy.position
+            score = value_func(enemy) + (1 - pos.distance_to(unit) / lookup)
+            if enemy.tag == last_target:
+                score += 1
+
+            if step.focus_fired.get(enemy.tag, 0) > enemy.health:
+                score *= 0.1
+
+            if score > best_score:
+                best_target = enemy
+                best_score = score
+
+        if best_target:
+            step.focus_fired[best_target.tag] = step.focus_fired.get(best_target.tag, 0)
+            return Action(best_target, True)
+
+        return current_command
+
+    @staticmethod
+    def ready_to_shoot(step: MicroStep, unit: Unit) -> bool:
+        delay_to_shoot = step.client.game_step + 1.5
+
+        if unit.type_id == UnitTypeId.CYCLONE:
+            if step.cd_manager.is_ready(unit.tag, AbilityId.CANCEL_LOCKON):
+                return False
+
+        if unit.type_id == UnitTypeId.DISRUPTOR:
+            return step.cd_manager.is_ready(unit.tag, AbilityId.EFFECT_PURIFICATIONNOVA)
+
+        if unit.type_id == UnitTypeId.ORACLE:
+            tick = step.ai.state.game_loop % 16
+            return tick < 8
+
+        if unit.type_id == UnitTypeId.CARRIER:
+            tick = step.ai.state.game_loop % 32
+            return tick < 8
+
+        return unit.weapon_cooldown <= delay_to_shoot

--- a/sharpy/managers/combat2/micro_rules.py
+++ b/sharpy/managers/combat2/micro_rules.py
@@ -17,10 +17,11 @@ from sharpy.managers.combat2.default_micro_methods import DefaultMicroMethods
 
 if TYPE_CHECKING:
     from sharpy.knowledges import Knowledge
+    from sharpy.managers.group_combat_manager import GroupCombatManager
 
 
 class MicroRules(Component):
-    regroup_func: Callable[[Point2, List[CombatUnits]], None]  # TODO: How will this work?
+    handle_groups_func: Callable[["GroupCombatManager", Point2, MoveType], None]
     init_group_func: Callable[[MicroStep, CombatUnits, Units, List[CombatUnits], MoveType], None]
     group_solve_combat_func: Callable[[MicroStep, Units, Action], Action]
     unit_solve_combat_func: Callable[[MicroStep, Unit, Action], Action]
@@ -46,6 +47,7 @@ class MicroRules(Component):
             await micro.start(knowledge)
 
     def load_default_methods(self):
+        self.handle_groups_func = DefaultMicroMethods.handle_groups
         self.init_group_func = DefaultMicroMethods.init_micro_group
         # Pass command
         self.group_solve_combat_func = lambda step, units, current_command: current_command

--- a/sharpy/managers/combat2/micro_rules.py
+++ b/sharpy/managers/combat2/micro_rules.py
@@ -37,6 +37,8 @@ class MicroRules(Component):
         self.regroup_threshold = 0.75
         # How much distance must be between units to consider them to be in different groups, set to 0 for no grouping
         self.own_group_threshold = 7
+        # In order to avoid exceptions, let's set default generic micro to something.
+        self.generic_micro = MicroStep()
 
     async def start(self, knowledge: "Knowledge"):
         await super().start(knowledge)

--- a/sharpy/managers/combat2/micro_rules.py
+++ b/sharpy/managers/combat2/micro_rules.py
@@ -1,0 +1,108 @@
+from typing import Dict, Callable, Optional, List
+
+from sc2 import UnitTypeId
+from sc2.position import Point2
+from sc2.unit import Unit
+from sc2.units import Units
+from sharpy.general.component import Component
+
+from sharpy.managers.combat2.protoss import *
+from sharpy.managers.combat2.terran import *
+from sharpy.managers.combat2.zerg import *
+from sharpy.managers.combat2 import *
+
+from typing import TYPE_CHECKING
+
+from sharpy.managers.combat2.default_micro_methods import DefaultMicroMethods
+
+if TYPE_CHECKING:
+    from sharpy.knowledges import Knowledge
+
+
+class MicroRules(Component):
+    regroup_func: Callable[[Point2, List[CombatUnits]], None]  # TODO: How will this work?
+    init_group_func: Callable[[MicroStep, CombatUnits, Units, List[CombatUnits], MoveType], None]
+    group_solve_combat_func: Callable[[MicroStep, Units, Action], Action]
+    unit_solve_combat_func: Callable[[MicroStep, Unit, Action], Action]
+    ready_to_shoot_func: Callable[[MicroStep, Unit], bool]
+    focus_fire_func: Callable[[MicroStep, Unit, Action, Optional[Dict[UnitTypeId, int]]], Action]
+    melee_focus_fire_func: Callable[[MicroStep, Unit, Action, Optional[Dict[UnitTypeId, int]]], Action]
+    generic_micro: MicroStep
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.regroup = True
+        self.unit_micros: Dict[UnitTypeId, MicroStep] = dict()
+        self.regroup_threshold = 0.75
+        # How much distance must be between units to consider them to be in different groups, set to 0 for no grouping
+        self.own_group_threshold = 7
+
+    async def start(self, knowledge: "Knowledge"):
+        await super().start(knowledge)
+
+        await self.generic_micro.start(knowledge)
+
+        for micro in self.unit_micros.values():
+            await micro.start(knowledge)
+
+    def load_default_methods(self):
+        self.init_group_func = DefaultMicroMethods.init_micro_group
+        # Pass command
+        self.group_solve_combat_func = lambda step, units, current_command: current_command
+        # Pass command
+        self.unit_solve_combat_func = lambda step, unit, current_command: current_command
+
+        self.ready_to_shoot_func = DefaultMicroMethods.ready_to_shoot
+
+        self.focus_fire_func = DefaultMicroMethods.focus_fire
+        self.melee_focus_fire_func = DefaultMicroMethods.melee_focus_fire
+
+    def load_default_micro(self):
+        # Micro controllers / handlers
+        self.unit_micros[UnitTypeId.DRONE] = MicroWorkers()
+        self.unit_micros[UnitTypeId.PROBE] = MicroWorkers()
+        self.unit_micros[UnitTypeId.SCV] = MicroWorkers()
+
+        # Protoss
+        self.unit_micros[UnitTypeId.ARCHON] = NoMicro()
+        self.unit_micros[UnitTypeId.ADEPT] = MicroAdepts()
+        self.unit_micros[UnitTypeId.CARRIER] = MicroCarriers()
+        self.unit_micros[UnitTypeId.COLOSSUS] = MicroColossi()
+        self.unit_micros[UnitTypeId.DARKTEMPLAR] = MicroZerglings()
+        self.unit_micros[UnitTypeId.DISRUPTOR] = MicroDisruptor()
+        self.unit_micros[UnitTypeId.DISRUPTORPHASED] = MicroPurificationNova()
+        self.unit_micros[UnitTypeId.HIGHTEMPLAR] = MicroHighTemplars()
+        self.unit_micros[UnitTypeId.OBSERVER] = MicroObservers()
+        self.unit_micros[UnitTypeId.ORACLE] = MicroOracles()
+        self.unit_micros[UnitTypeId.PHOENIX] = MicroPhoenixes()
+        self.unit_micros[UnitTypeId.SENTRY] = MicroSentries()
+        self.unit_micros[UnitTypeId.STALKER] = MicroStalkers()
+        self.unit_micros[UnitTypeId.WARPPRISM] = MicroWarpPrism()
+        self.unit_micros[UnitTypeId.VOIDRAY] = MicroVoidrays()
+        self.unit_micros[UnitTypeId.ZEALOT] = MicroZealots()
+
+        # Zerg
+        self.unit_micros[UnitTypeId.ZERGLING] = MicroZerglings()
+        self.unit_micros[UnitTypeId.ULTRALISK] = NoMicro()
+        self.unit_micros[UnitTypeId.OVERSEER] = MicroOverseers()
+        self.unit_micros[UnitTypeId.QUEEN] = MicroQueens()
+        self.unit_micros[UnitTypeId.RAVAGER] = MicroRavagers()
+
+        self.unit_micros[UnitTypeId.LURKERMP] = MicroLurkers()
+        self.unit_micros[UnitTypeId.INFESTOR] = MicroInfestors()
+        self.unit_micros[UnitTypeId.SWARMHOSTMP] = MicroSwarmHosts()
+        self.unit_micros[UnitTypeId.LOCUSTMP] = NoMicro()
+        self.unit_micros[UnitTypeId.LOCUSTMPFLYING] = NoMicro()
+        self.unit_micros[UnitTypeId.VIPER] = MicroVipers()
+
+        # Terran
+        self.unit_micros[UnitTypeId.HELLIONTANK] = NoMicro()
+        self.unit_micros[UnitTypeId.SIEGETANK] = MicroTanks()
+        self.unit_micros[UnitTypeId.VIKINGFIGHTER] = MicroVikings()
+        self.unit_micros[UnitTypeId.MARINE] = MicroBio()
+        self.unit_micros[UnitTypeId.MARAUDER] = MicroBio()
+        self.unit_micros[UnitTypeId.BATTLECRUISER] = MicroBattleCruisers()
+        self.unit_micros[UnitTypeId.RAVEN] = MicroRavens()
+        self.unit_micros[UnitTypeId.MEDIVAC] = MicroMedivacs()
+
+        self.generic_micro = GenericMicro()

--- a/sharpy/managers/combat2/micro_step.py
+++ b/sharpy/managers/combat2/micro_step.py
@@ -15,6 +15,7 @@ from sc2.units import Units
 from ...general.component import Component
 
 if TYPE_CHECKING:
+    from .micro_rules import MicroRules
     from sharpy.managers import *
 
 changelings = {
@@ -31,6 +32,7 @@ class MicroStep(ABC, Component):
     engaged_power: ExtendedPower
     our_power: ExtendedPower
     delay_to_shoot: float
+    enemies_near_by: Units
 
     def __init__(self):
         self.enemy_groups: List[CombatUnits] = []
@@ -53,211 +55,43 @@ class MicroStep(ABC, Component):
         await super().start(knowledge)
         self.engaged_power = ExtendedPower(knowledge.unit_values)
         self.our_power = ExtendedPower(knowledge.unit_values)
-        self.delay_to_shoot = self.client.game_step + 1.5
 
-    def init_group(self, group: CombatUnits, units: Units, enemy_groups: List[CombatUnits], move_type: MoveType):
+    def init_group(
+        self,
+        rules: "MicroRules",
+        group: CombatUnits,
+        units: Units,
+        enemy_groups: List[CombatUnits],
+        move_type: MoveType,
+    ):
+        self.rules = rules
+
         self.focus_fired.clear()
         self.group = group
         self.move_type = move_type
-        ready_to_attack = 0
 
         self.our_power = group.power
         self.closest_units.clear()
         self.engaged_power.clear()
 
-        self.closest_group = group.closest_target_group(enemy_groups)
-        if self.closest_group:
-            self.closest_group_distance = group.center.distance_to(self.closest_group.center)
-        else:
-            self.closest_group_distance = 100000
-        self.enemy_groups = enemy_groups
-        self.center = units.center
-        self.enemies_near_by: Units = self.knowledge.unit_cache.enemy_in_range(self.center, 15 + len(group.units) * 0.1)
-
-        self.engaged_power.add_units(self.enemies_near_by)
-
-        engage_count = 0
-        can_engage_count = 0
-        self.attack_range = 0
-        self.enemy_attack_range = 0
-        attack_range_count = 0
-        enemy_attack_range_count = 0
-
-        for unit in units:
-            closest_distance = 1000
-            if self.ready_to_shoot(unit):
-                ready_to_attack += 1
-
-            engage_added = False
-            can_engage_added = False
-            for enemy_near in self.enemies_near_by:  # type: Unit
-                d = enemy_near.distance_to(unit)
-                if d < closest_distance:
-                    self.closest_units[unit.tag] = enemy_near
-                    closest_distance = d
-
-                att_range = self.unit_values.real_range(enemy_near, unit)
-                self.enemy_attack_range += att_range
-                enemy_attack_range_count += 1
-                if not engage_added and d < att_range:
-                    engage_count += 1
-                    engage_added = True
-
-                att_range = self.unit_values.real_range(unit, enemy_near)
-                self.attack_range += att_range
-                attack_range_count += 1
-
-                if not can_engage_added and d < att_range:
-                    can_engage_count += 1
-                    can_engage_added = True
-
-        if attack_range_count > 0:
-            self.attack_range = self.attack_range / attack_range_count
-
-        if enemy_attack_range_count > 0:
-            self.enemy_attack_range = self.enemy_attack_range / enemy_attack_range_count
-
-        self.ready_to_attack_ratio = ready_to_attack / len(units)
-        self.engage_ratio = engage_count / len(units)
-        self.can_engage_ratio = can_engage_count / len(units)
+        self.rules.init_group_func(self, group, units, enemy_groups, move_type)
 
     def ready_to_shoot(self, unit: Unit) -> bool:
-        if unit.type_id == UnitTypeId.CYCLONE:
-            # if knowledge.cooldown_manager.is_ready(self.unit.tag, AbilityId.LOCKON_LOCKON):
-            #     self.ready_to_shoot = True
-            #     return
-            if self.cd_manager.is_ready(unit.tag, AbilityId.CANCEL_LOCKON):
-                return False
+        return self.rules.ready_to_shoot_func(self, unit)
 
-        if unit.type_id == UnitTypeId.DISRUPTOR:
-            return self.cd_manager.is_ready(unit.tag, AbilityId.EFFECT_PURIFICATIONNOVA)
-
-        if unit.type_id == UnitTypeId.ORACLE:
-            tick = self.ai.state.game_loop % 16
-            return tick < 8
-
-        if unit.type_id == UnitTypeId.CARRIER:
-            tick = self.ai.state.game_loop % 32
-            return tick < 8
-
-        return unit.weapon_cooldown <= self.delay_to_shoot
-
-    @abstractmethod
     def group_solve_combat(self, units: Units, current_command: Action) -> Action:
-        pass
+        return self.rules.group_solve_combat_func(self, units, current_command)
 
-    @abstractmethod
     def unit_solve_combat(self, unit: Unit, current_command: Action) -> Action:
-        pass
+        return self.rules.unit_solve_combat_func(self, unit, current_command)
 
     def focus_fire(self, unit: Unit, current_command: Action, prio: Optional[Dict[UnitTypeId, int]]) -> Action:
-        shoot_air = self.unit_values.can_shoot_air(unit)
-        shoot_ground = self.unit_values.can_shoot_ground(unit)
+        return self.rules.focus_fire_func(self, unit, current_command, prio)
 
-        air_range = self.unit_values.air_range(unit)
-        ground_range = self.unit_values.ground_range(unit)
-        lookup = min(air_range + 3, ground_range + 3)
-        enemies = self.cache.enemy_in_range(unit.position, lookup)
-
-        last_target = self.last_targeted(unit)
-
-        if not enemies:
-            # No enemies to shoot at
-            return current_command
-
-        value_func: Callable[[Unit], float]
-        if prio:
-            value_func = (
-                lambda u: 1 if u.type_id in changelings else prio.get(u.type_id, -1) * (1 - u.shield_health_percentage)
-            )
-        else:
-            value_func = (
-                lambda u: 1
-                if u.type_id in changelings
-                else 2 * self.unit_values.power_by_type(u.type_id, 1 - u.shield_health_percentage)
-            )
-
-        best_target: Optional[Unit] = None
-        best_score: float = 0
-        for enemy in enemies:  # type: Unit
-            if not self.is_target(enemy):
-                continue
-
-            if not shoot_air and enemy.is_flying:
-                continue
-
-            if not shoot_ground and not enemy.is_flying:
-                continue
-
-            pos: Point2 = enemy.position
-            score = value_func(enemy) + (1 - pos.distance_to(unit) / lookup)
-            if enemy.tag == last_target:
-                score += 3
-
-            if self.focus_fired.get(enemy.tag, 0) > enemy.health:
-                score *= 0.1
-
-            if score > best_score:
-                best_target = enemy
-                best_score = score
-
-        if best_target:
-            self.focus_fired[best_target.tag] = (
-                self.focus_fired.get(best_target.tag, 0) + unit.calculate_damage_vs_target(best_target)[0]
-            )
-
-            return Action(best_target, True)
-
-        return current_command
-
-    def melee_focus_fire(self, unit: Unit, current_command: Action) -> Action:
-        ground_range = self.unit_values.ground_range(unit)
-        lookup = ground_range + 3
-        enemies = self.cache.enemy_in_range(unit.position, lookup)
-
-        last_target = self.last_targeted(unit)
-
-        if not enemies:
-            # No enemies to shoot at
-            return current_command
-
-        def melee_value(u: Unit):
-            val = 1 - u.shield_health_percentage
-            range = self.unit_values.real_range(unit, u)
-            if unit.distance_to(u) < range:
-                val += 2
-            if self.knowledge.enemy_race == Race.Terran and unit.is_structure and unit.build_progress < 1:
-                # if building isn't finished, focus on the possible scv instead
-                val -= 2
-            return val
-
-        value_func = melee_value
-        close_enemies = self.cache.enemy_in_range(unit.position, lookup)
-
-        best_target: Optional[Unit] = None
-        best_score: float = 0
-
-        for enemy in close_enemies:  # type: Unit
-            if enemy.is_flying:
-                continue
-
-            pos: Point2 = enemy.position
-            score = value_func(enemy) + (1 - pos.distance_to(unit) / lookup)
-            if enemy.tag == last_target:
-                score += 1
-
-            if self.focus_fired.get(enemy.tag, 0) > enemy.health:
-                score *= 0.1
-
-            if score > best_score:
-                best_target = enemy
-                best_score = score
-
-        if best_target:
-            self.focus_fired[best_target.tag] = self.focus_fired.get(best_target.tag, 0)
-            return Action(best_target, True)
-
-        return current_command
+    def melee_focus_fire(
+        self, unit: Unit, current_command: Action, prio: Optional[Dict[UnitTypeId, int]] = None
+    ) -> Action:
+        return self.rules.melee_focus_fire_func(self, unit, current_command, prio)
 
     def last_targeted(self, unit: Unit) -> Optional[int]:
         if unit.orders:

--- a/sharpy/managers/combat2/micro_step.py
+++ b/sharpy/managers/combat2/micro_step.py
@@ -33,6 +33,7 @@ class MicroStep(ABC, Component):
     our_power: ExtendedPower
     delay_to_shoot: float
     enemies_near_by: Units
+    closest_group: CombatUnits
 
     def __init__(self):
         self.enemy_groups: List[CombatUnits] = []

--- a/sharpy/managers/combat2/protoss/micro_adepts.py
+++ b/sharpy/managers/combat2/protoss/micro_adepts.py
@@ -68,9 +68,10 @@ high_priority: Dict[UnitTypeId, int] = {
 
 
 class MicroAdepts(GenericMicro):
-    def __init__(self):
+    def __init__(self, micro_shades: bool = True):
         super().__init__()
         self.prio_dict = high_priority
+        self.micro_shades = micro_shades
 
     def unit_solve_combat(self, unit: Unit, current_command: Action) -> Action:
         shuffler = unit.tag % 10
@@ -79,18 +80,18 @@ class MicroAdepts(GenericMicro):
         enemy: Unit
 
         target = self.get_target(self.enemies_near_by, target, unit, shuffler)
+        if self.micro_shades:
+            shade_tag = self.cd_manager.adept_to_shade.get(unit.tag, None)
+            if shade_tag:
+                shade = self.cache.by_tag(shade_tag)
+                if shade:
+                    if target is None:
+                        nearby: Units = self.knowledge.unit_cache.enemy_in_range(shade.position, 12)
+                        target = self.get_target(nearby, target, shade, shuffler)
 
-        shade_tag = self.cd_manager.adept_to_shade.get(unit.tag, None)
-        if shade_tag:
-            shade = self.cache.by_tag(shade_tag)
-            if shade:
-                if target is None:
-                    nearby: Units = self.knowledge.unit_cache.enemy_in_range(shade.position, 12)
-                    target = self.get_target(nearby, target, shade, shuffler)
-
-                if target is not None:
-                    pos: Point2 = target.position
-                    self.ai.do(shade.move(pos.towards(unit, -1)))
+                    if target is not None:
+                        pos: Point2 = target.position
+                        self.ai.do(shade.move(pos.towards(unit, -1)))
 
         if self.move_type in {MoveType.SearchAndDestroy, MoveType.Assault} and self.model == CombatModel.RoachToStalker:
             if self.cd_manager.is_ready(unit.tag, AbilityId.ADEPTPHASESHIFT_ADEPTPHASESHIFT):


### PR DESCRIPTION
micro rules class added that can be customized and most of the code moved from micro_step to default micro methods that handles the implementation details in separate methods that can be passed around and changes freely.

`GroupCombatManager` now has a default set of micro rules with unit dictionaries in it, but they can be temporarily overridden by passing a `MicroRules` class to `self.combat.execute` method.