### PR TITLE
General improvements to dummy bots

### DIFF
--- a/bot_loader/bot_definitions.py
+++ b/bot_loader/bot_definitions.py
@@ -45,18 +45,48 @@ difficulty = {
 
 
 class DummyBuilder:
-    def __init__(self, key: str, name: str, race: Race, file_name: str, bot_type: type) -> None:
+    def __init__(self, key: str, name: str, race: Race, file_name: str, bot_type: type, params_count: int = 0) -> None:
         self.key = key
         self.name = name
         self.race: Race = race
         self.file_name = file_name
         self.bot_type = bot_type
+        self.params_count = params_count
 
     def build_definition(self) -> Tuple[Callable[[List[str]], AbstractPlayer], Optional[LadderZip]]:
         race: str = self.race.name
         folder = race.lower()
         zip_builder = DummyZip(self.name, race, os.path.join("dummies", folder, self.file_name))
-        return (lambda params: Bot(self.race, self.bot_type()), zip_builder)
+        if self.params_count == 0:
+            return (lambda params: Bot(self.race, self.bot_type()), zip_builder)
+        if self.params_count == 1:
+            return (
+                lambda params: Bot(self.race, self.bot_type(BotDefinitions.index_check(params, 0, "default"))),
+                zip_builder,
+            )
+        if self.params_count == 2:
+            return (
+                lambda params: Bot(
+                    self.race,
+                    self.bot_type(
+                        BotDefinitions.index_check(params, 0, "default"),
+                        BotDefinitions.index_check(params, 1, "default"),
+                    ),
+                ),
+                zip_builder,
+            )
+        if self.params_count == 3:
+            return (
+                lambda params: Bot(
+                    self.race,
+                    self.bot_type(
+                        BotDefinitions.index_check(params, 0, "default"),
+                        BotDefinitions.index_check(params, 1, "default"),
+                        BotDefinitions.index_check(params, 2, "default"),
+                    ),
+                ),
+                zip_builder,
+            )
 
 
 class BotDefinitions:
@@ -124,7 +154,7 @@ class BotDefinitions:
 
     def _human(self) -> Dict[str, Tuple[Callable[[List[str]], AbstractPlayer], Optional[LadderZip]]]:
         # Human, must be player 1
-        return {"human": ((lambda params: Human(races[self.index_check(params, 0, "random")])), None)}
+        return {"human": ((lambda params: Human(races[BotDefinitions.index_check(params, 0, "random")])), None)}
 
     def _ai(self) -> Dict[str, Tuple[Callable[[List[str]], AbstractPlayer], Optional[LadderZip]]]:
         # Ingame ai, can be player 1 or 2 and cannot be published
@@ -132,9 +162,9 @@ class BotDefinitions:
             "ai": (
                 (
                     lambda params: Computer(
-                        races[self.index_check(params, 0, "random")],
-                        difficulty[self.index_check(params, 1, "veryhard")],
-                        builds[self.index_check(params, 2, "random")],
+                        races[BotDefinitions.index_check(params, 0, "random")],
+                        difficulty[BotDefinitions.index_check(params, 1, "veryhard")],
+                        builds[BotDefinitions.index_check(params, 2, "random")],
                     )
                 ),
                 None,
@@ -191,7 +221,8 @@ class BotDefinitions:
         assert ladder_zip is None or isinstance(ladder_zip, LadderZip)
         self.bots[key] = (func, ladder_zip)
 
-    def index_check(self, items: List[str], index: int, default: str) -> str:
+    @staticmethod
+    def index_check(items: List[str], index: int, default: Optional[str]) -> str:
         """
         Simple method for parsing arguments with a default value if argument index not foung
         @param items: arguments
@@ -209,7 +240,7 @@ class BotDefinitions:
             # Protoss
             DummyBuilder("4gate", "SharpRush", Race.Protoss, "gate4.py", Stalkers4Gate),
             DummyBuilder("adept", "SharpShades", Race.Protoss, "adept_allin.py", AdeptRush),
-            DummyBuilder("cannonrush", "SharpCannons", Race.Protoss, "cannon_rush.py", CannonRush),
+            DummyBuilder("cannonrush", "SharpCannons", Race.Protoss, "cannon_rush.py", CannonRush, params_count=1),
             DummyBuilder("disruptor", "SharpSpheres", Race.Protoss, "disruptor.py", SharpSphereBot),
             DummyBuilder("dt", "SharpShadows", Race.Protoss, "dark_templar_rush.py", DarkTemplarRush),
             DummyBuilder("robo", "SharpRobots", Race.Protoss, "robo.py", MacroRobo),
@@ -232,10 +263,10 @@ class BotDefinitions:
             # DummyBuilder("roachrush", "SharpShades", Race.Zerg, "adept_allin.py", RoachRush),
             # Terran
             DummyBuilder("banshee", "RustyScreams", Race.Terran, "banshees.py", Banshees),
-            DummyBuilder("bc", "FlyingRust", Race.Terran, "battle_cruisers.py", BattleCruisers),
+            DummyBuilder("bc", "FlyingRust", Race.Terran, "battle_cruisers.py", BattleCruisers, params_count=1),
             DummyBuilder("bio", "RustyInfantry", Race.Terran, "bio.py", BioBot),
             DummyBuilder("cyclone", "RustyLocks", Race.Terran, "cyclones.py", CycloneBot),
-            DummyBuilder("marine", "RustyMarines", Race.Terran, "marine_rush.py", MarineRushBot),
+            DummyBuilder("marine", "RustyMarines", Race.Terran, "marine_rush.py", MarineRushBot, params_count=1),
             DummyBuilder("oldrusty", "OldRusty", Race.Terran, "rusty.py", Rusty),
             DummyBuilder("tank", "RustyTanks", Race.Terran, "two_base_tanks.py", TwoBaseTanks),
             DummyBuilder("terranturtle", "RustyOneBaseTurtle", Race.Terran, "one_base_turtle.py", OneBaseTurtle),
@@ -259,13 +290,13 @@ class BotDefinitions:
 
         buildable_only = {
             "cannonrush_1": DummyZip(
-                "SharpCannonRush", "Protoss", os.path.join("dummies", "protoss", "cannon_rush.py"), "cannon_rush = 0"
+                "SharpCannonRush", "Protoss", os.path.join("dummies", "protoss", "cannon_rush.py"), "cannonrush = 0"
             ),
             "cannonrush_2": DummyZip(
-                "SharpCannonContain", "Protoss", os.path.join("dummies", "protoss", "cannon_rush.py"), "cannon_rush = 1"
+                "SharpCannonContain", "Protoss", os.path.join("dummies", "protoss", "cannon_rush.py"), "cannonrush = 1"
             ),
             "cannonrush_3": DummyZip(
-                "SharpCannonExpand", "Protoss", os.path.join("dummies", "protoss", "cannon_rush.py"), "cannon_rush = 2"
+                "SharpCannonExpand", "Protoss", os.path.join("dummies", "protoss", "cannon_rush.py"), "cannonrush = 2"
             ),
             "marine_1": DummyZip(
                 "RustyMarines1", "Terran", os.path.join("dummies", "terran", "marine_rush.py"), "marine = 0"
@@ -275,6 +306,9 @@ class BotDefinitions:
             ),
             "marine_3": DummyZip(
                 "RustyMarines3", "Terran", os.path.join("dummies", "terran", "marine_rush.py"), "marine = 2"
+            ),
+            "bcjump": DummyZip(
+                "FlyingRustJump", "Terran", os.path.join("dummies", "terran", "battle_cruisers.py"), "bc = 1"
             ),
         }
 

--- a/config.ini
+++ b/config.ini
@@ -36,7 +36,7 @@ ActUnit = yes
 ChronoUnitProduction = yes
 GridBuilding = yes
 
-PlanDistributeWorkers = no
+DistributeWorkers = no
 WorkerScout = no
 DoubleAdeptScout = no
 ProtossBuildOrderSelector = yes

--- a/dummies/debug/debug_units_dummy.py
+++ b/dummies/debug/debug_units_dummy.py
@@ -1,5 +1,5 @@
 from sharpy.plans.require import Time
-from sharpy.plans.tactics import PlanDistributeWorkers, PlanZoneAttack
+from sharpy.plans.tactics import DistributeWorkers, PlanZoneAttack
 from sc2 import UnitTypeId
 
 from sharpy.knowledges import KnowledgeBot
@@ -17,7 +17,7 @@ class DebugUnitsDummy(KnowledgeBot):
         attack.retreat_multiplier = 0.1
         attack.attack_on_advantage = False
 
-        return BuildOrder([PlanDistributeWorkers(), Step(Time(60), attack)])
+        return BuildOrder([DistributeWorkers(), Step(Time(60), attack)])
 
     async def on_step(self, iteration):
         # Hack so that BuildingSolver is finally ready to give positions for the debug buildings.

--- a/dummies/debug/expand_bot.py
+++ b/dummies/debug/expand_bot.py
@@ -1,4 +1,4 @@
-from sharpy.plans.tactics import PlanDistributeWorkers
+from sharpy.plans.tactics import DistributeWorkers
 from sc2 import UnitTypeId
 
 from sharpy.knowledges import KnowledgeBot
@@ -13,4 +13,4 @@ class ExpandDummy(KnowledgeBot):
         super().__init__("ExpandDummy")
 
     async def create_plan(self) -> BuildOrder:
-        return BuildOrder(Expand(2, priority=True, consider_worker_production=False), PlanDistributeWorkers())
+        return BuildOrder(Expand(2, priority=True, consider_worker_production=False), DistributeWorkers())

--- a/dummies/debug/restore_power_dummy.py
+++ b/dummies/debug/restore_power_dummy.py
@@ -1,4 +1,4 @@
-from sharpy.plans.tactics import PlanDistributeWorkers
+from sharpy.plans.tactics import DistributeWorkers
 from sc2 import UnitTypeId
 
 from sharpy.knowledges import KnowledgeBot
@@ -13,7 +13,7 @@ class RestorePowerDummy(KnowledgeBot):
         super().__init__("RestorePowerDummy")
 
     async def create_plan(self) -> BuildOrder:
-        return BuildOrder([RestorePower(), PlanDistributeWorkers()])
+        return BuildOrder([RestorePower(), DistributeWorkers()])
 
     async def on_step(self, iteration):
         # Hack so that BuildingSolver is finally ready to give positions for the debug buildings.

--- a/dummies/protoss/adept_allin.py
+++ b/dummies/protoss/adept_allin.py
@@ -74,7 +74,7 @@ class AdeptRush(KnowledgeBot):
             SequentialList(
                 PlanZoneDefense(),
                 RestorePower(),
-                PlanDistributeWorkers(),
+                DistributeWorkers(),
                 PlanZoneGather(),
                 DoubleAdeptScout(number),
                 attack,

--- a/dummies/protoss/cannon_rush.py
+++ b/dummies/protoss/cannon_rush.py
@@ -188,11 +188,16 @@ class ProxyCannoneer(ActBase):
 
 
 class CannonRush(KnowledgeBot):
-    def __init__(self):
+    def __init__(self, build_name: str = "default"):
         super().__init__("Sharp Cannon")
+        self.build_name = build_name
 
     async def create_plan(self) -> BuildOrder:
-        rnd = select_build_index(self.knowledge, "build.cannon_rush", 0, 2)
+        if self.build_name == "default":
+            rnd = select_build_index(self.knowledge, "build.cannonrush", 0, 2)
+        else:
+            rnd = int(self.build_name)
+
         self.knowledge.building_solver.wall_type = WallType.NoWall
         rush_killed = RequireCustom(
             lambda k: self.knowledge.lost_units_manager.own_lost_type(UnitTypeId.PROBE) >= 3 or self.time > 4 * 60

--- a/dummies/protoss/cannon_rush.py
+++ b/dummies/protoss/cannon_rush.py
@@ -253,7 +253,7 @@ class CannonRush(KnowledgeBot):
             SequentialList(
                 PlanCancelBuilding(),
                 PlanZoneDefense(),
-                PlanDistributeWorkers(),
+                DistributeWorkers(),
                 PlanZoneGather(),
                 PlanZoneAttack(6),
                 PlanFinishEnemy(),

--- a/dummies/protoss/dark_templar_rush.py
+++ b/dummies/protoss/dark_templar_rush.py
@@ -128,7 +128,7 @@ class DarkTemplarRush(KnowledgeBot):
             PlanCancelBuilding(),
             PlanZoneDefense(),
             RestorePower(),
-            PlanDistributeWorkers(),
+            DistributeWorkers(),
             DtPush(),
             PlanZoneGather(),
             attack,

--- a/dummies/protoss/disruptor.py
+++ b/dummies/protoss/disruptor.py
@@ -66,7 +66,7 @@ class DistruptorBuild(BuildOrder):
             PlanCancelBuilding(),
             WorkerRallyPoint(),
             RestorePower(),
-            PlanDistributeWorkers(),
+            DistributeWorkers(),
             PlanWorkerOnlyDefense(),  # Counter worker rushes
             PlanZoneDefense(),
             PlanZoneGather(),

--- a/dummies/protoss/gate4.py
+++ b/dummies/protoss/gate4.py
@@ -56,7 +56,7 @@ class Stalkers4Gate(KnowledgeBot):
             SequentialList(
                 PlanZoneDefense(),
                 RestorePower(),
-                PlanDistributeWorkers(),
+                DistributeWorkers(),
                 PlanZoneGather(),
                 Step(TechReady(UpgradeId.BLINKTECH, 0.9), attack),
                 PlanFinishEnemy(),

--- a/dummies/protoss/macro_stalkers.py
+++ b/dummies/protoss/macro_stalkers.py
@@ -49,7 +49,7 @@ class MacroStalkers(KnowledgeBot):
             SequentialList(
                 PlanZoneDefense(),
                 RestorePower(),
-                PlanDistributeWorkers(),
+                DistributeWorkers(),
                 PlanZoneGather(),
                 Step(UnitReady(UnitTypeId.GATEWAY, 4), PlanZoneAttack(4)),
                 PlanFinishEnemy(),

--- a/dummies/protoss/one_base_tempests.py
+++ b/dummies/protoss/one_base_tempests.py
@@ -43,7 +43,7 @@ class OneBaseTempests(KnowledgeBot):
                 SequentialList(
                     PlanZoneDefense(),
                     RestorePower(),
-                    PlanDistributeWorkers(),
+                    DistributeWorkers(),
                     PlanZoneGather(),
                     Step(UnitExists(UnitTypeId.TEMPEST, 1, include_killed=True), attack),
                     PlanFinishEnemy(),

--- a/dummies/protoss/proxy_zealot_rush.py
+++ b/dummies/protoss/proxy_zealot_rush.py
@@ -180,7 +180,7 @@ class ProxyZealotRushBot(KnowledgeBot):
                         backup,
                     ]
                 ),
-                [PlanDistributeWorkers(), PlanZoneDefense(), PlanZoneGather(), attack, PlanFinishEnemy()],
+                [DistributeWorkers(), PlanZoneDefense(), PlanZoneGather(), attack, PlanFinishEnemy()],
                 ChronoUnit(UnitTypeId.ZEALOT, UnitTypeId.GATEWAY),
             ]
         )

--- a/dummies/protoss/robo.py
+++ b/dummies/protoss/robo.py
@@ -83,7 +83,7 @@ class MacroRobo(KnowledgeBot):
                 PlanHeatObserver(),
                 PlanZoneDefense(),
                 RestorePower(),
-                PlanDistributeWorkers(),
+                DistributeWorkers(),
                 PlanZoneGather(),
                 Step(UnitReady(UnitTypeId.IMMORTAL, 3), attack),
                 PlanFinishEnemy(),

--- a/dummies/protoss/voidray.py
+++ b/dummies/protoss/voidray.py
@@ -84,7 +84,7 @@ class MacroVoidray(KnowledgeBot):
             SequentialList(
                 PlanZoneDefense(),
                 RestorePower(),
-                PlanDistributeWorkers(),
+                DistributeWorkers(),
                 PlanZoneGather(),
                 Step(UnitReady(UnitTypeId.VOIDRAY, 3), attack),
                 PlanFinishEnemy(),

--- a/dummies/terran/banshees.py
+++ b/dummies/terran/banshees.py
@@ -25,7 +25,7 @@ class Banshees(KnowledgeBot):
         self.knowledge.print(f"Att at {attack_value}", "Build")
 
         worker_scout = Step(None, WorkerScout(), skip_until=UnitExists(UnitTypeId.SUPPLYDEPOT, 1))
-        self.distribute_workers = PlanDistributeWorkers(4)
+        self.distribute_workers = DistributeWorkers(4)
         tactics = [
             PlanCancelBuilding(),
             LowerDepots(),

--- a/dummies/terran/bio.py
+++ b/dummies/terran/bio.py
@@ -207,7 +207,7 @@ class BioBot(KnowledgeBot):
             Step(None, CallMule(50), skip=Time(5 * 60)),
             Step(None, CallMule(100), skip_until=Time(5 * 60)),
             Step(None, ScanEnemy(), skip_until=Time(5 * 60)),
-            PlanDistributeWorkers(),
+            DistributeWorkers(),
             ManTheBunkers(),
             Repair(),
             ContinueBuilding(),

--- a/dummies/terran/cyclones.py
+++ b/dummies/terran/cyclones.py
@@ -59,7 +59,7 @@ class CycloneBot(KnowledgeBot):
         self.attack = PlanZoneAttack(40)
 
         worker_scout = Step(None, WorkerScout(), skip_until=UnitExists(UnitTypeId.SUPPLYDEPOT, 1))
-        self.distribute_workers = PlanDistributeWorkers()
+        self.distribute_workers = DistributeWorkers()
 
         tactics = [
             PlanCancelBuilding(),

--- a/dummies/terran/marine_rush.py
+++ b/dummies/terran/marine_rush.py
@@ -42,15 +42,19 @@ class DodgeRampAttack(PlanZoneAttack):
 class MarineRushBot(KnowledgeBot):
     tactic_index: int
 
-    def __init__(self):
+    def __init__(self, build_name: str = "default"):
         super().__init__("Marine Rush")
+        self.build_name = build_name
 
     async def pre_step_execute(self):
         if self.tactic_index != 1 and self.time < 5 * 60:
             self.knowledge.gather_point = self.knowledge.expansion_zones[-2].gather_point
 
     async def create_plan(self) -> BuildOrder:
-        self.tactic_index = select_build_index(self.knowledge, "build.marine", 0, 2)
+        if self.build_name == "default":
+            self.tactic_index = select_build_index(self.knowledge, "build.marine", 0, 2)
+        else:
+            self.tactic_index = int(self.build_name)
 
         if self.tactic_index == 0:
             self.knowledge.print("Proxy 2 rax bunker rush", "Build")

--- a/dummies/terran/marine_rush.py
+++ b/dummies/terran/marine_rush.py
@@ -118,7 +118,7 @@ class MarineRushBot(KnowledgeBot):
         empty = BuildOrder([])
 
         worker_scout = Step(None, WorkerScout(), skip_until=UnitExists(UnitTypeId.SUPPLYDEPOT, 1))
-        self.distribute_workers = PlanDistributeWorkers()
+        self.distribute_workers = DistributeWorkers()
 
         tactics = [
             PlanCancelBuilding(),

--- a/dummies/terran/one_base_turtle.py
+++ b/dummies/terran/one_base_turtle.py
@@ -61,7 +61,7 @@ class OneBaseTurtle(KnowledgeBot):
             LowerDepots(),
             PlanZoneDefense(),
             CallMule(),
-            PlanDistributeWorkers(),
+            DistributeWorkers(),
             Repair(),
             ContinueBuilding(),
             PlanZoneGatherTerran(),

--- a/dummies/terran/rusty.py
+++ b/dummies/terran/rusty.py
@@ -138,7 +138,7 @@ class Rusty(KnowledgeBot):
             worker_scout,
             CallMule(100),
             ScanEnemy(),
-            PlanDistributeWorkers(),
+            DistributeWorkers(),
             ManTheBunkers(),
             Repair(),
             ContinueBuilding(),

--- a/dummies/terran/safe_tvt_raven.py
+++ b/dummies/terran/safe_tvt_raven.py
@@ -47,16 +47,16 @@ class TerranSafeTvT(KnowledgeBot):
 
         gas_management = [
             # Mine with 6 workers until first barracks is complete
-            Step(None, PlanDistributeWorkers(6), skip=UnitReady(UnitTypeId.BARRACKS)),
+            Step(None, DistributeWorkers(6), skip=UnitReady(UnitTypeId.BARRACKS)),
             # Mine with 4 workers until the natural CC is started
             Step(
                 None,
-                PlanDistributeWorkers(4, 4),
+                DistributeWorkers(4, 4),
                 skip_until=UnitReady(UnitTypeId.BARRACKS),
                 skip=UnitExists(UnitTypeId.COMMANDCENTER, 2),
             ),
             # Mine with at least 9 workers afterwards
-            Step(None, PlanDistributeWorkers(min_gas=9), skip_until=UnitExists(UnitTypeId.COMMANDCENTER, 2)),
+            Step(None, DistributeWorkers(min_gas=9), skip_until=UnitExists(UnitTypeId.COMMANDCENTER, 2)),
         ]
 
         units = [

--- a/dummies/terran/two_base_tanks.py
+++ b/dummies/terran/two_base_tanks.py
@@ -95,7 +95,7 @@ class TwoBaseTanks(KnowledgeBot):
             scout,
             ScanEnemy(120),
             CallMule(),
-            PlanDistributeWorkers(),
+            DistributeWorkers(),
             Repair(),
             ContinueBuilding(),
             PlanZoneGatherTerran(),

--- a/dummies/zerg/lings.py
+++ b/dummies/zerg/lings.py
@@ -220,7 +220,7 @@ class LingFlood(KnowledgeBot):
         worker_scout = Step(
             None, WorkerScout(), skip_until=RequireCustom(lambda k: len(self.enemy_start_locations) > 1)
         )
-        distribute = PlanDistributeWorkers()
+        distribute = DistributeWorkers()
 
         return BuildOrder(
             [
@@ -244,9 +244,9 @@ class LingFlood(KnowledgeBot):
                         worker_scout,
                         SpreadCreep(),
                         InjectLarva(),
-                        Step(None, PlanDistributeWorkers(3, 3), skip=Any([stop_gas, end_game])),
-                        Step(None, PlanDistributeWorkers(0, 0), skip_until=stop_gas, skip=end_game),
-                        Step(None, PlanDistributeWorkers(None, None), skip_until=end_game),
+                        Step(None, DistributeWorkers(3, 3), skip=Any([stop_gas, end_game])),
+                        Step(None, DistributeWorkers(0, 0), skip_until=stop_gas, skip=end_game),
+                        Step(None, DistributeWorkers(None, None), skip_until=end_game),
                         DummyZergAttack(),
                     ]
                 ),

--- a/dummies/zerg/lurkers.py
+++ b/dummies/zerg/lurkers.py
@@ -172,7 +172,7 @@ class LurkerBot(KnowledgeBot):
                 Step(None, WorkerScout(), skip_until=Supply(20)),
                 SpreadCreep(),
                 InjectLarva(),
-                PlanDistributeWorkers(),
+                DistributeWorkers(),
                 PlanZoneAttack(),
                 PlanFinishEnemy(),
             ),

--- a/dummies/zerg/macro_roach.py
+++ b/dummies/zerg/macro_roach.py
@@ -95,7 +95,7 @@ class MacroRoach(KnowledgeBot):
             PlanCancelBuilding(),
             SpreadCreep(),
             InjectLarva(),
-            PlanDistributeWorkers(),
+            DistributeWorkers(),
             PlanZoneDefense(),
             PlanZoneGather(),
             attack,

--- a/dummies/zerg/macro_zerg_v2.py
+++ b/dummies/zerg/macro_zerg_v2.py
@@ -77,7 +77,7 @@ class MacroZergV2(KnowledgeBot):
         tactics = [
             PlanCancelBuilding(),
             InjectLarva(),
-            PlanDistributeWorkers(),
+            DistributeWorkers(),
             attack,
             PlanFinishEnemy(),
         ]

--- a/dummies/zerg/mutalisk.py
+++ b/dummies/zerg/mutalisk.py
@@ -108,7 +108,7 @@ class MutaliskBot(KnowledgeBot):
             skip=RequireCustom(lambda k: len(self.enemy_start_locations) == 1),
             skip_until=Supply(20),
         )
-        distribute = PlanDistributeWorkers()
+        distribute = DistributeWorkers()
 
         return BuildOrder(
             MutaliskBuild(),

--- a/dummies/zerg/roach_hydra.py
+++ b/dummies/zerg/roach_hydra.py
@@ -92,7 +92,7 @@ class RoachHydra(KnowledgeBot):
             skip=RequireCustom(lambda k: len(self.enemy_start_locations) == 1),
             skip_until=Supply(20),
         )
-        self.distribute = PlanDistributeWorkers()
+        self.distribute = DistributeWorkers()
 
         return BuildOrder(
             RoachHydraBuild(),

--- a/dummies/zerg/twelve_pool.py
+++ b/dummies/zerg/twelve_pool.py
@@ -69,7 +69,7 @@ class TwelvePool(KnowledgeBot):
             finish,
             build_step_units,
             AutoOverLord(),
-            PlanDistributeWorkers(),
+            DistributeWorkers(),
             InjectLarva(),
             PlanWorkerOnlyDefense(),
             PlanZoneDefense(),

--- a/dummies/zerg/worker_rush.py
+++ b/dummies/zerg/worker_rush.py
@@ -228,9 +228,9 @@ class WorkerRush(KnowledgeBot):
             LingFloodBuild(),
             SequentialList(
                 InjectLarva(),
-                Step(None, PlanDistributeWorkers(3, 3), skip=Any([stop_gas, end_game])),
-                Step(None, PlanDistributeWorkers(0, 0), skip_until=stop_gas, skip=end_game),
-                Step(None, PlanDistributeWorkers(None, None), skip_until=end_game),
+                Step(None, DistributeWorkers(3, 3), skip=Any([stop_gas, end_game])),
+                Step(None, DistributeWorkers(0, 0), skip_until=stop_gas, skip=end_game),
+                Step(None, DistributeWorkers(None, None), skip_until=end_game),
                 WorkerAttack(),
                 DummyZergAttack(),
             ),

--- a/sharpy/plans/tactics/zerg/counter_terran_tie.py
+++ b/sharpy/plans/tactics/zerg/counter_terran_tie.py
@@ -8,7 +8,7 @@ from sc2.ids.buff_id import BuffId
 from sc2.unit import Unit
 from sharpy.plans.acts.zerg import MorphLair, ZergUnit, AutoOverLord
 from sharpy.plans.require import Supply
-from sharpy.plans.tactics import PlanDistributeWorkers
+from sharpy.plans.tactics import DistributeWorkers
 
 
 class CounterTerranTie(BuildOrder):
@@ -16,11 +16,11 @@ class CounterTerranTie(BuildOrder):
         """
         Build order package that replaces normal build order for Zerg with one that builds mutalisks to destroy terran
         flying buildings.
-        Add any PlanDistributeWorkers acts with orders
+        Add any DistributeWorkers acts with orders
         """
         cover_list = SequentialList(
             [
-                PlanDistributeWorkers(),
+                DistributeWorkers(),
                 AutoOverLord(),
                 Step(None, ZergUnit(UnitTypeId.DRONE, 20), skip=Supply(198)),
                 StepBuildGas(4, None),


### PR DESCRIPTION
Dummy bots can now have parameters to launch them with certain build variations
Made all dummy bots use the non-deprecated version of Distribute workers