### PR TITLE
nonblocking AutoWorker

### DIFF
--- a/sharpy/plans/acts/auto_worker.py
+++ b/sharpy/plans/acts/auto_worker.py
@@ -23,7 +23,8 @@ class AutoWorker(ActBase):
 
     async def execute(self) -> bool:
         self.act.to_count = min(self.to_count, self._optimal_count())
-        return await self.act.execute()
+        await self.act.execute()
+        return True
 
     def _optimal_count(self) -> int:
         count = 1


### PR DESCRIPTION
Seems more useful to be able to put this inside a sequential build order when you want to relinquish manual worker management? I think the main use case is when you 12 pool/pylon/depot and want to start autoworker after that first structure.