### PR TITLE
Algorithm argument for DBSCAN

### DIFF
--- a/sharpy/combat/group_combat_manager.py
+++ b/sharpy/combat/group_combat_manager.py
@@ -217,7 +217,7 @@ class GroupCombatManager(ManagerBase, ICombatManager):
             numpy_vectors.append(np.array([unit.position.x, unit.position.y]))
 
         if numpy_vectors:
-            clustering = DBSCAN(eps=self.enemy_group_distance, min_samples=1).fit(numpy_vectors)
+            clustering = DBSCAN(eps=self.enemy_group_distance, min_samples=1, algorithm="kd_tree").fit(numpy_vectors)
             # print(clustering.labels_)
 
             for index in range(0, len(clustering.labels_)):


### PR DESCRIPTION
The default algorithm option for `DBSCAN` in `sklearn` is `auto` https://scikit-learn.org/stable/modules/generated/sklearn.cluster.DBSCAN.html

Turns out this has major performance issues on linux on the latest `sklearn` versions since `auto` makes some bad choices. There should be a noticeable improvement in step times on aiarena ladder

The algorithm choice of `kd_tree` has been well tested in Eris (despite not using sharpy it does use this very same function), and fairly certain Zoe has used this option for some time too.