### PR TITLE
adds --ladderversion flag, which runs game on version 4.10

### DIFF
--- a/bot_loader/game_starter.py
+++ b/bot_loader/game_starter.py
@@ -131,6 +131,11 @@ Builds:
             "--requirewin", help="Requires victory for the specified player number (1 or 2) or raise exception."
         )
 
+
+        parser.add_argument(
+            "--ladderversion", help="Uses v4.10 as on the ladder. Ensure you have v4.10 and run the download script.", action=argparse.BooleanOptionalAction, default=False
+        )
+
         args = parser.parse_args()
 
         player1: str = args.player1
@@ -190,11 +195,17 @@ Builds:
         else:
             LoggingUtility.set_logger(log_level=self.config["general"]["log_level"])
 
+        sc2_version = None
+        if(args.ladderversion):
+            sc2_version = "4.10"
+
         GameStarter.setup_bot(player1_bot, player1, player2, args)
         GameStarter.setup_bot(player2_bot, player2, player1, args)
 
         print(f"Starting game in {map_name}.")
         print(f"{player1} vs {player2}")
+
+
 
         runner = MatchRunner()
         result = runner.run_game(
@@ -205,6 +216,7 @@ Builds:
             game_time_limit=(30 * 60),
             save_replay_as=f"{folder}/{file_name}.SC2Replay",
             start_port=args.port,
+            sc2_version=sc2_version
         )
 
         if args.requirewin:

--- a/bot_loader/killable_process.py
+++ b/bot_loader/killable_process.py
@@ -3,7 +3,7 @@ import shutil
 import time
 
 from typing import Any
-from sc2.sc2process import kill_switch
+from sc2.sc2process import KillSwitch
 
 """
 Process that is automatically killed by sc2.
@@ -15,7 +15,7 @@ class KillableProcess:
         self._tmp_dir = tmp_dir
         self._process: Any = process
         super().__init__()
-        kill_switch.add(self)
+        KillSwitch.add(self)
 
     def _clean(self) -> None:
         """

--- a/sharpy/managers/core/unit_value.py
+++ b/sharpy/managers/core/unit_value.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Union, Optional, List, Callable
+from typing import Union, Optional, Dict, List, Callable
 
 from sc2.data import Race, race_townhalls
 from sharpy.general.unit_feature import UnitFeature


### PR DESCRIPTION
Depends on python-sc2 merge: https://github.com/BurnySc2/python-sc2/pull/213
As discussed, sometime in SC2 version 5.0.x, the map becomes unclickable and you can't issue unit commands.

To allow users to launch on v4.10 (which is the ladder version) this code adds the boolean switch `--ladderversion`.
It brings back the ability to navigate the minimap and issue commands while your bot is busy.

Note, I had to change some imports which were renamed on latest `python-sc2`.
The module `kill_switch` is now `KillSwitch`.

Tested against latest python-sc2 at the commit mentioned in the above PR.
If that gets merged, this can be merged. Works for bot-vs-ai and bot-vs-bot.